### PR TITLE
Add Randomizer 0.38.0

### DIFF
--- a/mods/ciddmandude@pokemon_randomizer/description.md
+++ b/mods/ciddmandude@pokemon_randomizer/description.md
@@ -1,0 +1,44 @@
+Pokemon Gen 1 Randomizer creates deterministic, seed-based playthroughs of Pokemon Red, Blue, and Yellow in Gen1Recomp. It is a mod-only randomizer and does not require an external app.
+
+Each New Game generates its results once and stores the seed, settings,compatibility information, and resolved mappings in the save file. Reloading the game therefore preserves the same run instead of rerolling its content.
+Settings changed later in the Options menu apply to the next New Game, not an existing save.
+
+## What it randomizes
+
+- Walking, surfing, and fishing encounters, including separate Old Rod, Good Rod, and Super Rod results.
+- The three selectable starters in Red and Blue, or the player Pikachu and rival Eevee sequence in Yellow.
+- Regular trainers, rival teams, Gym Leaders, the Elite Four, and Champion.
+- Supported static encounters, including the legendary birds, Mewtwo, both Snorlax encounters, and the Power Plant item-ball Pokemon.
+- Gift Pokemon, including fossils, the Fighting Dojo choices, Eevee, Lapras,the Magikarp seller, and supported Yellow-exclusive gifts.
+- Both sides of supported in-game trades.
+- Pokemon prizes, levels, and optional prices at the Celadon Game Corner Prize Exchange. TM prizes are not changed.
+
+## Settings and safeguards
+
+The Randomizer menu is available from the game's Options menu. Casual,Standard, and Chaos presets provide quick starting points, while Custom mode
+allows each category to be configured individually.
+
+Options include the species pool, legendary handling, duplicate policy,similar-strength or same-evolution-stage matching, level adjustment, boss and rival behavior, rival team continuity, starter selection, gift and trade rules, Catchability Guard, Progression Guard, and spoiler availability. Every randomization category can also be disabled independently.
+
+Catchability Guard attempts to keep non-legendary randomized species obtainable through normal Kanto progression. Progression Guard protects required and early-game battles from invalid or excessively extreme generated parties.
+Encounter rates, encounter-slot probability buckets, and normal Repel behavior remain unchanged.
+
+## Spoiler log
+
+When spoilers are enabled for a run, the in-game spoiler browser can be searched by Pokemon or explored by location on the Kanto map. It displays wild encounters by method and level, complete trainer parties, starters, static and
+gift Pokemon, trades, and Game Corner prizes.
+
+A plaintext spoiler log can also be exported manually. The mod requests filesystem permission only for this explicit export and never writes a spoiler
+file automatically when a game begins.
+
+## Credits
+
+- Randomizer design and development: **ciddmandude**
+- [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp): **bryanthaboi** and
+  its contributors
+- Thanks to the Gen1Recomp community and everyone who tested the mod and reported issues.
+
+Pokemon and all related trademarks belong to their respective owners. This is an unofficial, fan-made mod and is not affiliated with or endorsed by Nintendo,
+Creatures Inc., or GAME FREAK inc.
+
+Source code, releases, documentation, and issue tracking are available at[github.com/ciddmandude/PokemonRecompRandomizer](https://github.com/ciddmandude/PokemonRecompRandomizer).

--- a/mods/ciddmandude@pokemon_randomizer/meta.json
+++ b/mods/ciddmandude@pokemon_randomizer/meta.json
@@ -1,0 +1,21 @@
+{
+  "id": "pokemon_randomizer",
+  "title": "Randomizer",
+  "author": "ciddmandude",
+  "version": "0.38.0",
+  "categories": [
+    "OTHER"
+  ],
+  "repo": "https://github.com/ciddmandude/PokemonRecompRandomizer",
+  "summary": "Randomize settings in game",
+  "tags": [
+    "randomizer"
+  ],
+  "github": "ciddmandude/PokemonRecompRandomizer",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content",
+  "experimental": true
+}


### PR DESCRIPTION
Adds `mods/ciddmandude@pokemon_randomizer/` — **Randomizer** 0.38.0 by ciddmandude.

- Source: https://github.com/ciddmandude/PokemonRecompRandomizer
- Releases tracked from: `ciddmandude/PokemonRecompRandomizer`
- Categories: OTHER
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>