### PR TITLE
Add three mods by MadeinTaly

### DIFF
--- a/mods/MadeinTaly@gen3_box/description.md
+++ b/mods/MadeinTaly@gen3_box/description.md
@@ -1,0 +1,37 @@
+# A box you can actually see
+
+Gen 1's PC shows twenty names in a list, and moving a Pokemon between boxes
+means withdrawing it, changing box, and depositing it again. This is the
+Ruby/Sapphire answer to that.
+
+A 5x4 grid of the current box. **A** picks a Pokemon up and **A** puts it
+down, swapping with whatever is already in the slot. **B** over a Pokemon
+opens its summary. **START** closes. **SELECT** crosses to your party and
+back, which is how you deposit and withdraw. Walking off the left or right
+edge changes box.
+
+`OPEN FROM` chooses where it is reachable: the start menu, the Pokemon
+Center PC, or both. The vanilla box PC is left in place either way.
+
+## Why the grid uses battle pics
+
+Gen 3's grid works because every species has its own icon. Gen 1 has no such
+thing: the icon table maps a species to one of a handful of shapes and the
+whole game carries four icon images, so a grid of those would be twenty
+identical blobs — strictly worse than the list it replaces. The grid draws
+each Pokemon's front pic at exactly half scale instead. The integer divisor
+keeps two-bit pixel art crisp, and the arithmetic fits: five columns of 28
+is 140 across a 160-wide screen, four rows is 112 of the 144 down.
+
+They are read through the engine's `Assets.image`, the same seam a sprite
+mod shadows, so an animated-sprite mod's art shows up in this grid too.
+
+## Safety
+
+A box stays a compact array — the shape the save format and the vanilla PC
+read — so dropping into an empty cell appends rather than leaving a hole.
+The party can never be emptied, a box never passes 20 and a party never
+passes 6, and if you are carrying a Pokemon while both are full the screen
+refuses to close rather than dropping it out of the save.
+
+Lua source only: no ROM, no ROM-derived data, no game assets.

--- a/mods/MadeinTaly@gen3_box/meta.json
+++ b/mods/MadeinTaly@gen3_box/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "gen3_box",
+  "title": "Gen 3 Box",
+  "author": "MadeinTaly",
+  "version": "1.2.1",
+  "categories": ["UI", "QOL"],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-boxes",
+  "github": "MadeinTaly/gen1recomp-gen3-boxes",
+  "summary": "A Gen 3-style storage screen: a 5x4 grid, a cursor that picks a Pokemon up and puts it down, and one button between box and party.",
+  "tags": ["boxes", "storage", "pc", "qol", "ui"],
+  "permissions": ["engine_internals"],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}

--- a/mods/MadeinTaly@modern_kanto/description.md
+++ b/mods/MadeinTaly@modern_kanto/description.md
@@ -1,0 +1,47 @@
+# Four fixes Gen 1 never got
+
+**Beta.** Every piece switches on its own, and the ones that move the
+balance are off until you turn them on.
+
+## SPLIT — the Gen 4 move split
+
+Gen 1 takes the category from the TYPE: every Water move is special, every
+Normal move physical. So Gyarados — 125 Attack, 60 Special — throws Hydro
+Pump off the wrong stat, and Hitmonchan cannot meaningfully use its
+elemental punches.
+
+The engine already supports the per-move answer; Gen 1 just never fills the
+field. `Damage.categoryOf` reads "the move's own category field wins, then
+the merged type record's". So this is 17 registry patches — pure data, no
+damage hook — and it composes with anything else that touches a battle.
+
+## GHOST FIX — on by default, on its own switch
+
+Ghost does **0x** to Psychic in Gen 1, where 2x was intended. Gen 1's only
+Ghost moves sit on Poison-typed Pokemon, which Psychic resists, so Psychic
+ends the generation with no counterplay at all.
+
+That is a bug, so it is separate from the other three chart rows, which are
+Gen 2 rebalancing a working table and live behind TYPE CHART. All four were
+read out of the decoded chart, and a test asserts the ROM still says what
+the mod claims.
+
+## SMART AI — a fix, not an addition
+
+Registering a new AI layer does nothing: TrainerAI walks the trainer class's
+own list of layers, so an id nobody references never runs. This patches
+LAYER_3, the vanilla type pass, whose own comment admits it "only reads the
+FIRST matching row -- no dual-type product". That is why a trainer throws
+Earthquake at a Pidgey: it sees the 2x against Rock and never reaches the
+Flying immunity. This multiplies them out.
+
+It still only nudges scores; vanilla's other passes run untouched.
+
+## ATLAS — what lives where
+
+Gen 1 holds a complete encounter table and shows none of it. The Atlas reads
+the merged dataset — so a mod that edits encounters appears here too — folds
+slots into one row per species with its real level range, and marks each
+against your dex.
+
+Lua source only: no ROM, no ROM-derived data, no game assets.

--- a/mods/MadeinTaly@modern_kanto/meta.json
+++ b/mods/MadeinTaly@modern_kanto/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "modern_kanto",
+  "title": "Modern Kanto",
+  "author": "MadeinTaly",
+  "version": "0.1.0",
+  "categories": ["GAMEPLAY", "BALANCE", "UI"],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-modern-kanto",
+  "github": "MadeinTaly/gen1recomp-modern-kanto",
+  "summary": "Four fixes Gen 1 never got: the move split, the corrected type rows, an AI that multiplies, and an encounter atlas.",
+  "tags": ["mechanic", "balance", "ui", "quality-of-life"],
+  "permissions": ["engine_internals"],
+  "api": 2,
+  "profile": "overhaul",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "experimental": true,
+  "automatic_version_check": true
+}

--- a/mods/MadeinTaly@running_shoes/description.md
+++ b/mods/MadeinTaly@running_shoes/description.md
@@ -1,0 +1,44 @@
+# Hold B, walk faster
+
+Gen 3 handed you running shoes in the first five minutes. Gen 1 made you
+walk to Cerulean, beat a gym, and buy a bicycle voucher off a man in a
+skyscraper.
+
+`RUN SPEED` picks the multiplier: x1.5, x2, x3 or x4. `BOOST BIKE` and
+`BOOST SURF` are off by default.
+
+## The numbers
+
+A step is a frame count and lower is faster. The engine walks you at 16
+frames a tile and rides the bicycle at 8, which is where "the bicycle
+doubles walking speed" comes from — it is exact.
+
+| Setting | Frames | Tiles/sec |
+| --- | ---: | ---: |
+| walking | 16 | 3.75 |
+| x1.5 | 11 | 5.45 |
+| x2 | 8 | 7.5 |
+| x3 | 5 | 12 |
+| x4 | 4 | 15 |
+
+At x2 your shoes *are* the bicycle — the same integer, not "about as fast
+as". You have matched a vehicle that costs a gym badge and an errand for a
+man on the eleventh floor, and the bicycle's remaining advantage is that it
+does not ask you to hold a button.
+
+The ladder stops at x4 because steps are whole frames. One rung further is
+3, then 2, then 1 — and at 1 frame a tile passes in a sixtieth of a second,
+which is 60 tiles a second, which is not running.
+
+## What it does not do
+
+There is no sprint animation: Gen 1 has no running frames, because in 1996
+nobody had thought of it. The legs keep the walking cadence and simply spend
+less time per tile.
+
+Nothing but the duration of a step changes. Collision, encounters, triggers,
+ledges and warps are untouched, so grass is no safer for having been crossed
+quickly. It rides the engine's own `movement.speed` hook — whose comment
+names running shoes as the reason it exists — calls the next handler first
+and multiplies its answer, so a mod that slows you in a swamp keeps its say.
+It declares no permissions at all.

--- a/mods/MadeinTaly@running_shoes/meta.json
+++ b/mods/MadeinTaly@running_shoes/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "running_shoes",
+  "title": "Running Shoes",
+  "author": "MadeinTaly",
+  "version": "1.0.0",
+  "categories": ["QOL", "GAMEPLAY"],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-running-shoes",
+  "github": "MadeinTaly/gen1recomp-running-shoes",
+  "summary": "Hold B to walk faster, at a speed you pick. Gen 3 gave you these in five minutes; Gen 1 made you earn a bicycle.",
+  "tags": ["quality-of-life", "movement", "running", "beginner"],
+  "permissions": [],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}


### PR DESCRIPTION
Three mods, each in its own repository with an MIT licence, a test suite
that runs through the headless loader, and a green `modkit validate` +
`lint`. Releases are published from CI and named `<id>-<version>.zip`, so
the index's automatic version check has something to read.

- **Gen 3 Box** — a Ruby/Sapphire-style storage screen: a 5x4 grid drawn
  from the per-species battle pics, a cursor that picks a Pokemon up and
  puts it down, and SELECT to cross between box and party.
- **Running Shoes** — hold B to walk faster, at a speed you pick. Rides the
  `movement.speed` hook and declares no permissions.
- **Modern Kanto** (beta) — the Gen 4 physical/special split as per-move
  data, the type-chart rows Gen 2 corrected including the Ghost/Psychic
  zero, an AI type pass that multiplies both defender types instead of
  reading the first row, and an encounter atlas.

All three ship Lua source only: no ROM, no ROM-derived data, no game
assets.
