### PR TITLE
Add description for Dual Screen (DS-style) mod

### DIFF
--- a/mods/BartInTheField@gen1recomp_ds/description.md
+++ b/mods/BartInTheField@gen1recomp_ds/description.md
@@ -1,0 +1,1 @@
+Stacks the world pass (top) and UI pass (bottom) as two Game Boy screens via the engine's render.compose seam, with a DS-native battle split (battlefield on top, command/move/text window on bottom); drives the bottom screen onto a second physical display on multi-display Android.


### PR DESCRIPTION
Stacks the world pass and UI pass as two Game Boy screens with a DS-native battle split, utilizing a second display on multi-display Android.

<!-- The submission helper fills this in for you: https://bryanthaboi.github.io/gen1recomp-mod-index/ -->

**Mod:** Dual Screen (DS-style), 2026.8.1+1
**Folder:** `BartInTheField@gen1recomp_ds/`
**Source:** https://github.com/BartInTheField/gen1recomp-ds-mod

- [ ] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [ ] the distributed `.zip` has the mod's files at the archive root
- [ ] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [ ] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [ ] this PR only touches `mods/<Author>@<id>/`

<!-- Version bumps do not need a PR: entries with "github" and
     automatic_version_check are re-read from your Releases nightly. -->
