### PR TITLE
Add meta.json for Dual Screen mod by BartInTheField

### DIFF
--- a/mods/BartInTheField@gen1recomp_ds/meta.json
+++ b/mods/BartInTheField@gen1recomp_ds/meta.json
@@ -1,0 +1,22 @@
+{
+  "id": "gen1recomp_ds",
+  "title": "Dual Screen (DS-style)",
+  "author": "BartInTheField",
+  "version": "2026.8.1+1",
+  "categories": [
+    "UI"
+  ],
+  "repo": "https://github.com/BartInTheField/gen1recomp-ds-mod",
+  "summary": "Stacks the world and UI as two separated screens.",
+  "tags": [
+    "ds",
+    "dual screen",
+    "ayn thor"
+  ],
+  "github": "BartInTheField/gen1recomp-ds-mod",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
<!-- The submission helper fills this in for you: https://bryanthaboi.github.io/gen1recomp-mod-index/ -->

**Mod:** Dual Screen (DS-style), 2026.8.1+1
**Folder:** `BartInTheField@gen1recomp_ds/`
**Source:** https://github.com/BartInTheField/gen1recomp-ds-mod

- [ ] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [ ] the distributed `.zip` has the mod's files at the archive root
- [ ] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [ ] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [ ] this PR only touches `mods/<Author>@<id>/`

<!-- Version bumps do not need a PR: entries with "github" and
     automatic_version_check are re-read from your Releases nightly. -->
