### PR TITLE
Add Controller Rumble 1.0.1

### DIFF
--- a/mods/masterwebx@CONTROLLER_RUMBLE/description.md
+++ b/mods/masterwebx@CONTROLLER_RUMBLE/description.md
@@ -1,0 +1,45 @@
+# Controller Rumble for Gen 1
+
+A modern haptics upgrade for Pokémon Gen 1 Recomp. This mod recreates the classic Game Boy “shakes” and expands them with full controller rumble across battles, menus, overworld actions, and story events.
+
+## Features
+
+### Battle FX
+- Hit impacts  
+- Healing pulses  
+- EXP gain ticks  
+- Status effects  
+- Type effectiveness cues  
+
+### Ambient & Overworld
+- Fishing bites  
+- Field moves (Cut, Surf, Strength, Flash)  
+- Item pickups  
+- Pokédex interactions  
+- Slot machine shakes  
+
+### Story & Link Events
+- Catch wobble timing  
+- Successful captures  
+- Trades and link‑cable actions  
+- Scripted story moments  
+
+### Menus & Interface
+- Option toggles  
+- Save confirmations  
+- PC interactions  
+- Shop and item usage feedback  
+
+## Categories
+- **Battle FX**  
+- **Ambient**  
+- **Story**  
+- **Menus**
+
+## Intensity Options
+- **OFF**  
+- **LOW**  
+- **MEDIUM**  
+- **HIGH**
+
+Enhance your Gen 1 adventure with tactile feedback that feels natural, responsive, and fully integrated into the modern engine.

--- a/mods/masterwebx@CONTROLLER_RUMBLE/meta.json
+++ b/mods/masterwebx@CONTROLLER_RUMBLE/meta.json
@@ -1,0 +1,23 @@
+{
+  "id": "CONTROLLER_RUMBLE",
+  "title": "Controller Rumble",
+  "author": "masterwebx",
+  "version": "1.0.0",
+  "categories": [
+    "GAMEPLAY",
+    "QOL"
+  ],
+  "repo": "https://github.com/masterwebx/gen1recomp-controller-rumble/tree/main",
+  "summary": "Modern rumble support that brings Gen 1’s classic shakes to life across battles, menus, story moments, and the overworld.",
+  "tags": [
+    "controller",
+    "rumble",
+    "wex"
+  ],
+  "github": "masterwebx/gen1recomp-controller-rumble",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/masterwebx@CONTROLLER_RUMBLE/` — **Controller Rumble** 1.0.1 by masterwebx.

- Source: https://github.com/masterwebx/gen1recomp-controller-rumble/tree/main
- Releases tracked from: `masterwebx/gen1recomp-controller-rumble`
- Categories: GAMEPLAY, QOL
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>