### PR TITLE
Add translation-nl

### DIFF
--- a/mods/BartInTheField@translation-nl/description.md
+++ b/mods/BartInTheField@translation-nl/description.md
@@ -1,0 +1,23 @@
+# Dutch translation
+
+Dutch translation for Pokémon Red and Blue (Pokémon Rood & Blauw), generated
+from PokeCorpus by the
+[gen1recomp-dutch-generator](https://github.com/BartInTheField/gen1recomp-dutch-generator),
+a Dutch-only fork of the translation mod generator.
+
+Coverage for this build:
+
+- ROM catalog: **3106/3106 (100%)**
+- RBY-related engine strings: **285/383 (74.41%)**
+
+Some special characters may not display correctly in game, and some text
+remains untranslated; anything unfilled falls through to English.
+
+## Install
+
+1. Download `translation-nl-0.0.2.zip` from the
+   [releases page](https://github.com/BartInTheField/gen1recomp-dutch-generator/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "BartInTheField/gen1recomp-dutch-generator"` set, the launcher's **Update**
+and **Versions** buttons handle new releases from there.

--- a/mods/BartInTheField@translation-nl/meta.json
+++ b/mods/BartInTheField@translation-nl/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "translation-nl",
+  "title": "Dutch translation",
+  "author": "BartInTheField",
+  "summary": "Dutch translation for Pokémon Red and Blue, generated from PokeCorpus.",
+  "version": "0.0.2",
+  "categories": [
+    "TRANSLATION"
+  ],
+  "tags": [
+    "dutch",
+    "translation",
+    "nederlands"
+  ],
+  "repo": "https://github.com/BartInTheField/gen1recomp-dutch-generator",
+  "github": "BartInTheField/gen1recomp-dutch-generator",
+  "api": 2,
+  "game_version": ">=0.0.0-dev",
+  "profile": "content"
+}


### PR DESCRIPTION
Adds the index entry for `BartInTheField@translation-nl` (meta.json + description.md), pointing at the mod's GitHub repo and releases. Validated with `node scripts/validate.mjs`.