### PR TITLE
Add DRAMATIC_SHAPE

### DIFF
--- a/mods/DramaticShape@DRAMATIC_SHAPE/description.md
+++ b/mods/DramaticShape@DRAMATIC_SHAPE/description.md
@@ -1,0 +1,21 @@
+# Dramatic Shape Voxel Mod
+
+The overworld as a 3D diorama. Terrain is extruded into real geometry,
+occlusion comes from a depth buffer rather than a y-sort, characters stand as
+leaning sprite slabs, a shadow map throws real cast shadows across whatever
+they land on, and an optional tilt-shift pass turns the whole thing into a
+miniature.
+
+Battles are fought on the map itself, shot over the shoulder at the nearest
+clear ground with a slow parallax drift.
+
+Declares `affects_link: false`: link play is unaffected.
+
+## Install
+
+1. Download `DRAMATIC_SHAPE-1.4.0.zip` from the
+   [releases page](https://github.com/DramaticShape/DramaticShapeVoxelMod/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "DramaticShape/DramaticShapeVoxelMod"` set, the launcher's **Update**
+and **Versions** buttons handle new releases from there.

--- a/mods/DramaticShape@DRAMATIC_SHAPE/meta.json
+++ b/mods/DramaticShape@DRAMATIC_SHAPE/meta.json
@@ -1,0 +1,25 @@
+{
+  "id": "DRAMATIC_SHAPE",
+  "title": "Dramatic Shape Voxel Mod",
+  "author": "DramaticShape",
+  "summary": "The overworld as a 3D voxel diorama: extruded terrain, cast shadows, tilt-shift, and battles fought on the map itself.",
+  "version": "1.4.0",
+  "categories": [
+    "ART"
+  ],
+  "tags": [
+    "voxel",
+    "3d",
+    "graphics",
+    "diorama"
+  ],
+  "repo": "https://github.com/DramaticShape/DramaticShapeVoxelMod",
+  "github": "DramaticShape/DramaticShapeVoxelMod",
+  "api": 2,
+  "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ],
+  "affects_link": false
+}


### PR DESCRIPTION
Adds the index entry for `DramaticShape@DRAMATIC_SHAPE` (meta.json + description.md), pointing at the mod's GitHub repo and releases. Validated with `node scripts/validate.mjs`.