### PR TITLE
Add scripts/clean-utf8.mjs

### DIFF
--- a/scripts/clean-utf8.mjs
+++ b/scripts/clean-utf8.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Remove bytes that are not valid UTF-8 from the text files of index entries.
+//
+//   node scripts/clean-utf8.mjs             report every mods/ entry, fix nothing
+//   node scripts/clean-utf8.mjs --write     rewrite offending files in place
+//   node scripts/clean-utf8.mjs mods/You@my_mod [--write]   one entry
+//
+// Only meta.json and description.md are considered; thumbnails are binary and
+// left alone. Invalid sequences are dropped, not replaced, so a cleaned file
+// never gains U+FFFD replacement characters. Exit code is the number of files
+// that contained invalid bytes (0 = already clean), so CI can gate on it.
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const write = args.includes('--write');
+const targets = args.filter((a) => a !== '--write');
+
+const roots = targets.length ? targets : ['mods'];
+const files = [];
+for (const root of roots) {
+  if (statSync(root).isFile()) {
+    files.push(root);
+    continue;
+  }
+  for (const dir of readdirSync(root)) {
+    for (const name of ['meta.json', 'description.md']) {
+      const p = join(root, dir, name);
+      try {
+        statSync(p);
+        files.push(p);
+      } catch {
+        /* optional file absent */
+      }
+    }
+  }
+}
+
+const strict = new TextDecoder('utf-8', { fatal: true });
+const lossy = new TextDecoder('utf-8'); // invalid sequences become U+FFFD
+
+let dirty = 0;
+for (const file of files) {
+  const buf = readFileSync(file);
+  try {
+    strict.decode(buf);
+    continue; // already valid UTF-8
+  } catch {
+    dirty++;
+  }
+  const cleaned = lossy.decode(buf).replaceAll('�', '');
+  const removed = buf.length - Buffer.byteLength(cleaned, 'utf8');
+  console.log(`${write ? 'cleaned' : 'would clean'} ${file}: ${removed} invalid byte(s)`);
+  if (write) writeFileSync(file, cleaned);
+}
+
+console.log(
+  dirty === 0
+    ? `OK - ${files.length} file(s) checked, all valid UTF-8.`
+    : `${dirty} of ${files.length} file(s) contained invalid UTF-8${write ? ', rewritten' : ''}.`
+);
+process.exitCode = dirty;


### PR DESCRIPTION
Adds a cleaner that strips bytes that are not valid UTF-8 from entry text files (meta.json, description.md; thumbnails untouched).

- `node scripts/clean-utf8.mjs` reports across all of `mods/` without touching anything
- `node scripts/clean-utf8.mjs --write` rewrites offending files in place, dropping invalid sequences (no U+FFFD replacement characters introduced)
- exit code is the count of dirty files, so CI can gate on it

Current state of the index: all existing entries already pass (18 files checked, 0 invalid).