### PR TITLE
Run clean-utf8 as a PR check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,6 +50,14 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: UTF-8 clean
+        run: |
+          if [ -n "${{ steps.changed.outputs.folders }}" ]; then
+            node scripts/clean-utf8.mjs ${{ steps.changed.outputs.folders }}
+          else
+            node scripts/clean-utf8.mjs
+          fi
+
       - name: Validate
         run: |
           set -o pipefail

--- a/scripts/clean-utf8.mjs
+++ b/scripts/clean-utf8.mjs
@@ -19,21 +19,24 @@ const targets = args.filter((a) => a !== '--write');
 
 const roots = targets.length ? targets : ['mods'];
 const files = [];
+const pushEntryFiles = (dir) => {
+  for (const name of ['meta.json', 'description.md']) {
+    const p = join(dir, name);
+    try {
+      statSync(p);
+      files.push(p);
+    } catch {
+      /* optional file absent */
+    }
+  }
+};
 for (const root of roots) {
   if (statSync(root).isFile()) {
     files.push(root);
-    continue;
-  }
-  for (const dir of readdirSync(root)) {
-    for (const name of ['meta.json', 'description.md']) {
-      const p = join(root, dir, name);
-      try {
-        statSync(p);
-        files.push(p);
-      } catch {
-        /* optional file absent */
-      }
-    }
+  } else if (readdirSync(root).includes('meta.json')) {
+    pushEntryFiles(root); // a single mods/<Author>@<id> entry
+  } else {
+    for (const dir of readdirSync(root)) pushEntryFiles(join(root, dir));
   }
 }
 


### PR DESCRIPTION
Adds a UTF-8 step to the Validate submissions workflow: changed entry folders (or the whole of `mods/` on push) are scanned by `scripts/clean-utf8.mjs`, whose exit code is the number of files containing invalid UTF-8, so a submission with mangled bytes fails before the schema validator runs.

Also fixes the cleaner to accept a single `mods/<Author>@<id>` folder as a target, which is the shape the workflow passes.