### PR TITLE
Add duplicate entry checker

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,6 +58,9 @@ jobs:
             node scripts/clean-utf8.mjs
           fi
 
+      - name: No duplicate entries
+        run: node scripts/check-duplicates.mjs
+
       - name: Validate
         run: |
           set -o pipefail

--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Flag entries that list the same mod twice.
+//
+//   node scripts/check-duplicates.mjs
+//
+// Two entries collide when they share a mod id (the folder's id half and
+// meta.json's id are already tied together by validate.mjs), a github
+// owner/repo, or a downloadURL. Each is checked across the whole index, since
+// a duplicate is by nature a cross-entry problem. Exit code is the number of
+// duplicate groups (0 = no duplicates), so CI can gate on it.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const groups = new Map(); // "kind: value" -> [folder, ...]
+for (const dir of readdirSync('mods')) {
+  let meta;
+  try {
+    meta = JSON.parse(readFileSync(join('mods', dir, 'meta.json'), 'utf8'));
+  } catch {
+    continue; // not an entry; validate.mjs owns that complaint
+  }
+  const keys = [['id', meta.id?.toLowerCase()]];
+  if (meta.github) keys.push(['github', meta.github.toLowerCase()]);
+  if (meta.downloadURL) keys.push(['downloadURL', meta.downloadURL]);
+  for (const [kind, value] of keys) {
+    if (!value) continue;
+    const key = `${kind}: ${value}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(`mods/${dir}`);
+  }
+}
+
+let dupes = 0;
+for (const [key, folders] of groups) {
+  if (folders.length < 2) continue;
+  dupes++;
+  console.log(`duplicate ${key}\n${folders.map((f) => `  - ${f}`).join('\n')}`);
+}
+
+console.log(
+  dupes === 0
+    ? `OK - ${readdirSync('mods').length} entr(y|ies) checked, no duplicates.`
+    : `${dupes} duplicate group(s) found.`
+);
+process.exitCode = dupes;


### PR DESCRIPTION
Adds `scripts/check-duplicates.mjs`: two entries collide when they share a mod id, a `github` owner/repo, or a `downloadURL`, checked across the whole index. Exit code is the number of duplicate groups, and the Validate submissions workflow now runs it before the schema validator.

Current index: 19 entries, no duplicates.