### PR TITLE
Add battle_move_info, yellow_legacy_changes and bag_999_fill

### DIFF
--- a/mods/ShaneMcGovernIE@bag_999_fill/description.md
+++ b/mods/ShaneMcGovernIE@bag_999_fill/description.md
@@ -1,0 +1,14 @@
+# 999 Bag Slots - Test Fill
+
+Test companion to `bag_999`: raises the bag to 999 slots and pre-fills
+it with one of every item in the game on boot, so the capacity is
+visible in one glance.
+
+## Try it
+
+Enable the mod, boot, open your bag — it holds the whole item catalog.
+
+## Notes
+
+- Items already held are skipped, so reloading never inflates stacks.
+- Demo mod: remove it once the capacity is proven; the items stay.

--- a/mods/ShaneMcGovernIE@bag_999_fill/meta.json
+++ b/mods/ShaneMcGovernIE@bag_999_fill/meta.json
@@ -1,0 +1,15 @@
+{
+  "id": "bag_999_fill",
+  "title": "999 Bag Slots - Test Fill",
+  "author": "ShaneMcGovernIE",
+  "summary": "Test build: bag holds 999 slots and is pre-filled with every item on boot.",
+  "version": "1.0.1",
+  "categories": ["TOOL"],
+  "tags": ["bag", "test", "quality-of-life"],
+  "repo": "https://github.com/ShaneMcGovernIE/bag_999_fill",
+  "github": "ShaneMcGovernIE/bag_999_fill",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "profile": "content"
+}

--- a/mods/ShaneMcGovernIE@battle_move_info/description.md
+++ b/mods/ShaneMcGovernIE@battle_move_info/description.md
@@ -1,18 +1,18 @@
 # Battle Move Info
 
-In battle, press **L** (left shoulder): or **Q** on a keyboard: while a
-move is highlighted to open an info box with the move's **type**, **power**,
-**accuracy** and **effect**, including exact chances (like "10% burn
-chance").
+In battle, press **L** (left shoulder) — or **Q** on a keyboard — while a
+move is highlighted to open an info box with the move's **type**,
+**power**, **accuracy** and **effect**. Each line waits for an A/B press,
+and the battle pauses while the box is open.
 
-Each line waits for an **A/B** press before the next scrolls in, like a
-normal Gen 1 text box. A/B closes it, and the battle resumes.
+## Try it
 
-## Install
+Start a battle, open FIGHT, highlight a move, press L (or Q).
 
-1. Download `battle_move_info-1.1.2.zip` from the
-   [releases page](https://github.com/ShaneMcGovernIE/battle_move_info/releases).
-2. In the launcher: MODS → **Import mod .zip**.
+## Notes
 
-With `"github": "ShaneMcGovernIE/battle_move_info"` set, the launcher's **Update**
-and **Versions** buttons handle new releases from there.
+- Effect descriptions cover all 87 vanilla effect ids, with readable
+  fallbacks for unknown or mod-added ids.
+- Works in the classic and widescreen battle layouts.
+- Presses made while the box is open are dropped, so it never re-opens
+  after closing.

--- a/mods/ShaneMcGovernIE@battle_move_info/meta.json
+++ b/mods/ShaneMcGovernIE@battle_move_info/meta.json
@@ -2,23 +2,15 @@
   "id": "battle_move_info",
   "title": "Battle Move Info",
   "author": "ShaneMcGovernIE",
-  "summary": "In battle, press L (Q on keyboard) while a move is highlighted to see its type, power, accuracy and effect.",
+  "summary": "Press L (or Q) on a highlighted battle move to see its type, power, accuracy and effect.",
   "version": "1.1.2",
-  "categories": [
-    "UI",
-    "QOL"
-  ],
-  "tags": [
-    "battle",
-    "moves",
-    "info"
-  ],
+  "categories": ["UI"],
+  "tags": ["battle", "ui", "quality-of-life"],
   "repo": "https://github.com/ShaneMcGovernIE/battle_move_info",
   "github": "ShaneMcGovernIE/battle_move_info",
+  "automatic_version_check": true,
   "api": 2,
-  "game_version": ">=0.0.0-0 <2.0.0",
+  "game_version": ">=1.0.0 <2.0.0",
   "profile": "content",
-  "permissions": [
-    "engine_internals"
-  ]
+  "permissions": ["engine_internals"]
 }

--- a/mods/ShaneMcGovernIE@yellow_legacy_changes/description.md
+++ b/mods/ShaneMcGovernIE@yellow_legacy_changes/description.md
@@ -1,22 +1,13 @@
 # Yellow Legacy Changes
 
-Applies the **move changes** and **stat changes** from *Yellow Legacy* (all
-credit to SmithPlaysPokemon) to the Gen 1 recompilation:
+Brings the balance updates from Pokémon Yellow Legacy (all credit to
+**SmithPlaysPokemon**) to gen1recomp: 73 rebalanced moves, 5 type
+changes, 11 effect changes, a functional 2x Focus Energy, a flat 1/8
+Leech Seed drain, learnsets for all 151 species, TM/HM lists for 146,
+and encounter tables for 57 maps. The full stat change tables are on the
+GitHub.
 
-- All 73 move rebalances (power, accuracy, PP)
-- Type changes (Gust→Flying, Cut→Bug, Egg Bomb→Grass, Karate Chop→Fighting,
-  Slam→Dragon)
-- New and adjusted effect chances
-- Rebalanced base stats
+## Not included
 
-Full change tables: with `(+X)` / `(-X)` deltas from vanilla: are in the
-[repo README](https://github.com/ShaneMcGovernIE/yellow_legacy_changes).
-
-## Install
-
-1. Download `yellow_legacy_changes-1.1.0.zip` from the
-   [releases page](https://github.com/ShaneMcGovernIE/yellow_legacy_changes/releases).
-2. In the launcher: MODS → **Import mod .zip**.
-
-With `"github": "ShaneMcGovernIE/yellow_legacy_changes"` set, the launcher's **Update**
-and **Versions** buttons handle new releases from there.
+The hack's QoL/engine features (gen1recomp has its own), visuals/music,
+and trainer roster changes.

--- a/mods/ShaneMcGovernIE@yellow_legacy_changes/meta.json
+++ b/mods/ShaneMcGovernIE@yellow_legacy_changes/meta.json
@@ -2,23 +2,15 @@
   "id": "yellow_legacy_changes",
   "title": "Yellow Legacy Changes",
   "author": "ShaneMcGovernIE",
-  "summary": "Applies the move and stat rebalances from Yellow Legacy by TSP: buffed/nerfed moves, new types and effects, rebalanced base stats.",
+  "summary": "Move, stat, learnset, TM/HM and encounter changes from Pokémon Yellow Legacy by SmithPlaysPokemon.",
   "version": "1.1.0",
-  "categories": [
-    "BALANCE"
-  ],
-  "tags": [
-    "balance",
-    "yellow legacy",
-    "moves",
-    "stats"
-  ],
+  "categories": ["BALANCE"],
+  "tags": ["balance", "ruleset", "yellow-legacy"],
   "repo": "https://github.com/ShaneMcGovernIE/yellow_legacy_changes",
   "github": "ShaneMcGovernIE/yellow_legacy_changes",
+  "automatic_version_check": true,
   "api": 2,
-  "game_version": ">=0.0.0-0 <2.0.0",
+  "game_version": ">=1.0.0 <2.0.0",
   "profile": "content",
-  "permissions": [
-    "engine_internals"
-  ]
+  "permissions": ["engine_internals"]
 }


### PR DESCRIPTION
## What

Three mods by ShaneMcGovernIE, following the manual submission layout:

| Mod | Categories | Version |
|---|---|---|
| battle_move_info | UI | 1.1.2 |
| yellow_legacy_changes | BALANCE | 1.1.0 |
| bag_999_fill | TOOL | 1.0.1 |

Each entry has `"github": "ShaneMcGovernIE/<repo>"` and leaves
`automatic_version_check` on, so the nightly release job keeps the
listings current — no PRs needed per version bump.

All three validated with `node scripts/validate.mjs` (0 warnings).
Each mod passes `modkit validate` / `modkit lint` against the engine
tooling and ships a release `.zip` via the modkit release workflow.