### PR TITLE
Sync entry versions to newest releases

### DIFF
--- a/mods/masterwebx@CONTROLLER_RUMBLE/meta.json
+++ b/mods/masterwebx@CONTROLLER_RUMBLE/meta.json
@@ -2,7 +2,7 @@
   "id": "CONTROLLER_RUMBLE",
   "title": "Controller Rumble",
   "author": "masterwebx",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "categories": [
     "GAMEPLAY",
     "QOL"

--- a/mods/masterwebx@MUSIC_PLAYER/meta.json
+++ b/mods/masterwebx@MUSIC_PLAYER/meta.json
@@ -2,7 +2,7 @@
   "id": "MUSIC_PLAYER",
   "title": "Music Player",
   "author": "masterwebx",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "categories": [
     "AUDIO",
     "QOL"

--- a/mods/masterwebx@RUN_MODE/meta.json
+++ b/mods/masterwebx@RUN_MODE/meta.json
@@ -3,7 +3,7 @@
   "title": "Run Mode",
   "author": "masterwebx",
   "summary": "Hold B to run on the overworld: bike-speed steps while on foot, with HOLD or TOGGLE mode in OPTIONS.",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "categories": [
     "QOL",
     "GAMEPLAY"


### PR DESCRIPTION
Updates the recorded `version` for the three masterwebx entries to what their repos' newest releases actually are (CONTROLLER_RUMBLE 1.0.2, MUSIC_PLAYER 1.2.4, RUN_MODE 1.1.9). Cleaner, duplicate check, and validator all pass.