### PR TITLE
Fix 'no merge base' on PRs from stale forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="origin/${{ github.base_ref }}"
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            # no --depth here: a shallow fetch grafts main's tip parentless,
+            # so any PR from a fork that is behind main dies with "no merge
+            # base" (checkout already ran with fetch-depth: 0)
+            git fetch --no-tags origin "${{ github.base_ref }}"
             files=$(git diff --name-only "$base"...HEAD)
           else
             files=$(git ls-files 'mods/*')


### PR DESCRIPTION
The changed-entries step fetched the base branch with `--depth=1`, which grafts main's tip as parentless. A PR whose fork is behind main then has no reachable common ancestor and the diff dies with `fatal: origin/main...HEAD: no merge base` (seen on #24). Up-to-date branches pass because the merge base is main's tip itself, which is why only some submitters hit it. Checkout already runs with `fetch-depth: 0`, so the fix is just to drop `--depth=1`.