### PR TITLE
Add Widescreen Battle Intro by ShaneMcGovernIE

### DIFF
--- a/mods/ShaneMcGovernIE@widescreen_battle_intro/description.md
+++ b/mods/ShaneMcGovernIE@widescreen_battle_intro/description.md
@@ -1,0 +1,19 @@
+# Widescreen Battle Intro
+
+On windows wider than 4:3, the flash at the start of the battle intro
+(trainer battles' circle wipes) used to play inside a centered 160x144
+square while the frozen overworld showed around it. This mod extends the
+flash across the entire window, matching the fullscreen wipe that follows
+it, so the battle transition reads as one effect on any aspect ratio.
+
+On a 4:3 window nothing changes: the overlay is the same shade the
+letterbox square already shows.
+
+## Install
+
+1. Download `widescreen_battle_intro-1.0.0.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/gen1recomp-widescreen-battle-intro/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/gen1recomp-widescreen-battle-intro"` set, the launcher's **Update**
+and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@widescreen_battle_intro/meta.json
+++ b/mods/ShaneMcGovernIE@widescreen_battle_intro/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "widescreen_battle_intro",
+  "title": "Widescreen Battle Intro",
+  "author": "ShaneMcGovernIE",
+  "summary": "Extends the battle intro's flash effect across the whole window, so on non-4:3 displays it no longer plays inside a centered 4:3 square.",
+  "version": "1.0.0",
+  "categories": [
+    "QOL"
+  ],
+  "tags": [
+    "battle",
+    "visual",
+    "widescreen"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/gen1recomp-widescreen-battle-intro",
+  "github": "ShaneMcGovernIE/gen1recomp-widescreen-battle-intro",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.53 <2.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}


### PR DESCRIPTION
Adds the Widescreen Battle Intro mod: extends the battle intro transition's flash across the whole window on non-4:3 displays.

- modkit lint + validate pass (engine repo)
- release v1.0.0 with an installable zip (files at archive root)
- auto version check against the releases page