### PR TITLE
Add surround_audio, trainer_rematch and widescreen_battle_intro

### DIFF
--- a/mods/ShaneMcGovernIE@surround_audio/description.md
+++ b/mods/ShaneMcGovernIE@surround_audio/description.md
@@ -1,0 +1,23 @@
+# Stereo & 5.1 Audio
+
+Pokémon Crystal's SOUND option, ported to the 8-bit music of Red/Blue/Yellow:
+
+- **MONO** sums every music channel into both speakers.
+- **STEREO** splits the channels: 1-2 to the left speaker, 3-4 to the right.
+- **5.1** plays every sound effect (menu beeps, battle hits, cries, fanfares,
+  the low-health alarm) from the center channel.
+
+## Use
+
+1. Press **M** (keyboard) or **Select + R** (gamepad) to switch between
+   MONO and STEREO. The current song restarts so you hear the change
+   immediately.
+
+## Install
+
+1. Download `surround_audio-1.6.0.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/surround-audio/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/surround-audio"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@surround_audio/meta.json
+++ b/mods/ShaneMcGovernIE@surround_audio/meta.json
@@ -1,0 +1,25 @@
+{
+  "id": "surround_audio",
+  "title": "Stereo & 5.1 Audio",
+  "author": "ShaneMcGovernIE",
+  "version": "1.6.0",
+  "categories": [
+    "AUDIO"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/surround-audio",
+  "summary": "Pokémon Crystal's SOUND option, ported to Red/Blue/Yellow's 8-bit music: MONO, STEREO channel split, and 5.1 surround with center-channel sound effects.",
+  "tags": [
+    "audio",
+    "stereo",
+    "surround",
+    "music"
+  ],
+  "github": "ShaneMcGovernIE/surround-audio",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "profile": "content",
+  "automatic_version_check": true
+}

--- a/mods/ShaneMcGovernIE@trainer_rematch/description.md
+++ b/mods/ShaneMcGovernIE@trainer_rematch/description.md
@@ -1,0 +1,25 @@
+# Trainer Rematch
+
+Talk to any trainer you have already beaten and they challenge you to a
+rematch, with a YES/NO prompt.
+
+## How it works
+
+1. Beat a trainer, then walk up and talk to them again.
+2. They greet you with a line written for their class (each class speaks in
+   the voice it uses in its regular dialogue).
+3. Answer the prompt:
+   - **YES** — battle them again. The rematch pays **no money**: no trainer
+     prize and no Pay Day pickup.
+   - **NO** — they react in character: cocky classes mock you for being
+     scared, wise ones are understanding. Their normal post-battle line
+     still follows, so nothing from the base game is lost.
+
+## Install
+
+1. Download `trainer_rematch-0.1.0.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/trainer_rematch/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/trainer_rematch"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@trainer_rematch/meta.json
+++ b/mods/ShaneMcGovernIE@trainer_rematch/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "trainer_rematch",
+  "title": "Trainer Rematch",
+  "author": "ShaneMcGovernIE",
+  "version": "0.1.0",
+  "categories": [
+    "GAMEPLAY"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/trainer_rematch",
+  "summary": "Talk to any trainer you have already beaten and they challenge you to a rematch, with a YES/NO prompt.",
+  "tags": [
+    "trainers",
+    "rematch",
+    "battle"
+  ],
+  "github": "ShaneMcGovernIE/trainer_rematch",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "profile": "content",
+  "automatic_version_check": true
+}

--- a/mods/ShaneMcGovernIE@widescreen_battle_intro/description.md
+++ b/mods/ShaneMcGovernIE@widescreen_battle_intro/description.md
@@ -1,0 +1,20 @@
+# Widescreen Battle Intro
+
+On windows wider than 4:3, the flash that opens the battle intro for wild
+encounters — and for battles against a foe at least 3 levels above your
+lead — used to play inside a centered 160x144 square; this mod extends that
+flash across the entire window.
+
+The flash only plays for the circle wipes, which are exactly those two
+cases. Trainer battles use spiral / shrink / split wipes that have no flash
+and were already fullscreen via the engine's own cascade.
+
+## Install
+
+1. Download `widescreen_battle_intro-1.2.1.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/gen1recomp-widescreen-battle-intro/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/gen1recomp-widescreen-battle-intro"` set,
+the launcher's **Update** and **Versions** buttons handle new releases from
+there.

--- a/mods/ShaneMcGovernIE@widescreen_battle_intro/meta.json
+++ b/mods/ShaneMcGovernIE@widescreen_battle_intro/meta.json
@@ -1,0 +1,23 @@
+{
+  "id": "widescreen_battle_intro",
+  "title": "Widescreen Battle Intro",
+  "author": "ShaneMcGovernIE",
+  "version": "1.2.1",
+  "categories": [
+    "UI"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/gen1recomp-widescreen-battle-intro",
+  "summary": "Extends the battle-intro flash across the full window on widescreen displays, instead of a centered 160x144 square.",
+  "tags": [
+    "battle",
+    "widescreen",
+    "visual"
+  ],
+  "github": "ShaneMcGovernIE/gen1recomp-widescreen-battle-intro",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content",
+  "automatic_version_check": true
+}


### PR DESCRIPTION
Adds three ShaneMcGovernIE mods to the community index:

- **surround_audio** (Stereo & 5.1 Audio) — Crystal-style MONO/STEREO/5.1 sound output, v1.6.0
- **trainer_rematch** — talk to beaten trainers for a rematch, v0.1.0
- **widescreen_battle_intro** — battle-intro flash spans the full widescreen window, v1.2.1

All three: `automatic_version_check: true`, release zips in the repo's releases, validated clean with `scripts/validate.mjs`.