### PR TITLE
Add ShaneMcGovernIE@exp_share

### DIFF
--- a/mods/ShaneMcGovernIE@exp_share/description.md
+++ b/mods/ShaneMcGovernIE@exp_share/description.md
@@ -1,0 +1,34 @@
+# Exp Share (Gen 1 / Gen 5+ styles)
+
+Turn party-wide EXP on from the OPTIONS menu, and pick how it splits:
+the Gen 1 Exp. All way or the modern Gen 5+ way. Shared exp prints one
+"Exp is shared amongst the party" line instead of a gain message per
+Pokemon.
+
+## How it works
+
+1. Open OPTIONS and cycle the new **EXP SHARE** row with LEFT/RIGHT:
+   **OFF / GEN 1 / GEN 5+**.
+2. **GEN 1** (Exp. All): the Pokemon that fought split half the exp; the
+   whole party splits the other half — the vanilla Gen 1 split, including
+   its participant-division quirk.
+3. **GEN 5+**: the fighters keep the full exp split between them; every
+   alive bench Pokemon gets half a fighter's share.
+4. The fighters' own gains still print per Pokemon, then one
+   "Exp is shared amongst the party" line announces the shared exp, and
+   every level-up, stat box and move learning still shows for each
+   Pokemon that gained exp.
+5. **OFF** restores vanilla behavior exactly, including the vanilla
+   Exp. All item's per-Pokemon messages.
+
+Fainted Pokemon get no exp (matching Gen 5+ rules). The setting is saved
+per save file, like every other OPTIONS row.
+
+## Install
+
+1. Download `exp_share-0.1.1.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/exp_share/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/exp_share"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@exp_share/meta.json
+++ b/mods/ShaneMcGovernIE@exp_share/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "exp_share",
+  "title": "Exp Share (Gen 1 / Gen 5+ styles)",
+  "author": "ShaneMcGovernIE",
+  "version": "0.1.1",
+  "categories": [
+    "GAMEPLAY"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/exp_share",
+  "summary": "Party-wide EXP from the OPTIONS menu: Gen 1 Exp. All style or Gen 5+ style, with one shared-exp line instead of a message per Pokemon.",
+  "tags": [
+    "exp",
+    "share",
+    "qol"
+  ],
+  "github": "ShaneMcGovernIE/exp_share",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}

--- a/mods/ShaneMcGovernIE@exp_share/meta.json
+++ b/mods/ShaneMcGovernIE@exp_share/meta.json
@@ -2,7 +2,7 @@
   "id": "exp_share",
   "title": "Exp Share (Gen 1 / Gen 5+ styles)",
   "author": "ShaneMcGovernIE",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "categories": [
     "GAMEPLAY"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/description.md
+++ b/mods/ShaneMcGovernIE@qol_toggles/description.md
@@ -1,0 +1,30 @@
+# QoL Toggles
+
+Four quality-of-life switches in OPTIONS → **USEFUL TOGGLES**, each
+persisted with your preferences (they stay on across restarts and save
+files).
+
+## The switches
+
+1. **POISON SAVE** — a poisoned party member at 1 HP no longer faints
+   from out-of-battle poison damage; the poison subsides with *"X's
+   poison has subsided!"*
+2. **FULL HEAL CATCH** — every captured Pokémon is fully healed (HP,
+   status, and all PP), whether it joins the party or goes to a PC box.
+3. **INFINITE REPEL** — no wild encounters while walking through grass,
+   surfing, or in caves.  Fishing is unaffected, like the vanilla Repel
+   item.
+4. **FIELD MOVES ALL** — any Pokémon that can learn a field move
+   (level-up or TM/HM) can use it out of battle even without knowing it:
+   a Pidgey that never learned FLY can still FLY, a Clefable without
+   TELEPORT can still TELEPORT.  Badge gates and context rules still
+   apply — no FLY without the Thunder Badge, no SURF without the Soul
+   Badge, DIG only on its cave tilesets.
+
+## Notes
+
+- Toggles default to OFF; each flip is saved immediately to
+  options.lua, so toggles set from the title screen survive starting or
+  continuing a game.
+- FIELD MOVES ALL never touches battle: it only adds the out-of-battle
+  party-menu options.

--- a/mods/ShaneMcGovernIE@qol_toggles/description.md
+++ b/mods/ShaneMcGovernIE@qol_toggles/description.md
@@ -23,7 +23,7 @@ files).
 
 ## Notes
 
-- Toggles default to OFF; each flip is saved immediately to
+- Toggles ship ON except INFINITE REPEL; each flip is saved immediately to
   options.lua, so toggles set from the title screen survive starting or
   continuing a game.
 - FIELD MOVES ALL never touches battle: it only adds the out-of-battle

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -2,8 +2,8 @@
   "id": "qol_toggles",
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
-  "summary": "OPTIONS -> USEFUL TOGGLES submenu: poison survives at 1 HP, captures are fully healed with PP restored, an infinite repel, and every learnable field move usable without knowing it.",
-  "version": "1.1.3",
+  "summary": "OPTIONS -> USEFUL TOGGLES: nine switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP and instant flee.",
+  "version": "1.2.0",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -3,7 +3,7 @@
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
   "summary": "OPTIONS -> USEFUL TOGGLES submenu: poison survives at 1 HP, captures are fully healed with PP restored, an infinite repel, and every learnable field move usable without knowing it.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -2,7 +2,7 @@
   "id": "qol_toggles",
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
-  "summary": "OPTIONS -> USEFUL TOGGLES: ten switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee, heal on map change.",
+  "summary": "OPTIONS -> USEFUL TOGGLES: poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee, heal on map change.",
   "version": "1.3.0",
   "categories": [
     "QOL"

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -2,8 +2,8 @@
   "id": "qol_toggles",
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
-  "summary": "OPTIONS -> USEFUL TOGGLES: poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee, heal on map change.",
-  "version": "1.3.0",
+  "summary": "OPTIONS -> USEFUL TOGGLES: poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, max DVs, double EXP, instant flee, heal on map change, quick S.S. Anne.",
+  "version": "1.4.0",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -2,8 +2,8 @@
   "id": "qol_toggles",
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
-  "summary": "OPTIONS -> USEFUL TOGGLES: nine switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP and instant flee.",
-  "version": "1.2.2",
+  "summary": "OPTIONS -> USEFUL TOGGLES: ten switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee and heal-on-map-change.",
+  "version": "1.3.0",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "qol_toggles",
+  "title": "QoL Toggles",
+  "author": "ShaneMcGovernIE",
+  "summary": "OPTIONS -> USEFUL TOGGLES submenu: poison survives at 1 HP, captures are fully healed with PP restored, an infinite repel, and every learnable field move usable without knowing it.",
+  "version": "1.1.2",
+  "categories": [
+    "QOL"
+  ],
+  "tags": [
+    "toggles",
+    "options",
+    "qol"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/qol_toggles",
+  "github": "ShaneMcGovernIE/qol_toggles",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -3,7 +3,7 @@
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
   "summary": "OPTIONS -> USEFUL TOGGLES: nine switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP and instant flee.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -3,7 +3,7 @@
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
   "summary": "OPTIONS -> USEFUL TOGGLES: nine switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP and instant flee.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "categories": [
     "QOL"
   ],

--- a/mods/ShaneMcGovernIE@qol_toggles/meta.json
+++ b/mods/ShaneMcGovernIE@qol_toggles/meta.json
@@ -2,7 +2,7 @@
   "id": "qol_toggles",
   "title": "QoL Toggles",
   "author": "ShaneMcGovernIE",
-  "summary": "OPTIONS -> USEFUL TOGGLES: ten switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee and heal-on-map-change.",
+  "summary": "OPTIONS -> USEFUL TOGGLES: ten switches for poison survival, full-heal catches, infinite repel, learnable field moves, badgeless moves, always-catch, perfect DVs, double EXP, instant flee, heal on map change.",
   "version": "1.3.0",
   "categories": [
     "QOL"


### PR DESCRIPTION
Party-wide EXP from the OPTIONS menu: Gen 1 Exp. All style or Gen 5+ style, with one shared-exp line instead of a message per Pokemon.

- repo: https://github.com/ShaneMcGovernIE/exp_share
- version: 0.1.1 (release asset exp_share-0.1.1.zip)
- validated: OK - 1 entry checked, 0 warning(s).