### PR TITLE
Sync MadeinTaly mods: add Groovy Palette & Frames, update three versions

### DIFF
--- a/mods/MadeinTaly@gen3_box/meta.json
+++ b/mods/MadeinTaly@gen3_box/meta.json
@@ -2,7 +2,7 @@
   "id": "gen3_box",
   "title": "Gen 3 Box",
   "author": "MadeinTaly",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "categories": ["UI", "QOL"],
   "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-boxes",
   "github": "MadeinTaly/gen1recomp-gen3-boxes",

--- a/mods/MadeinTaly@groovy_palette/description.md
+++ b/mods/MadeinTaly@groovy_palette/description.md
@@ -1,0 +1,35 @@
+Thirty more entries on the game's **COLORS** row, and eight new borders for
+every text box and menu.
+
+**The palettes.** Twelve reconstruct another machine's hardware — Amiga
+Workbench, the C64 boot screen, a Virtual Boy, an amber terminal, a
+Spectrum, CGA — and eighteen are colour ideas the Game Boy never had:
+rainbow, fuchsia, vaporwave, sunset, toxic, noir. They join the engine's own
+list rather than replacing it, so the vanilla seven keep their positions and
+a save pointing at SGB still lands on SGB.
+
+**Previewing them.** Press **A** on `OPTION → COLORS` and the menu lifts off
+the game: the palette's name over the running world, left and right to walk
+the list, A to keep, B to put back the one you arrived with. Choosing a
+colour from a menu that is covering the game is choosing it blind.
+
+**Riding ADVANCED.** The engine's ADVANCED mode resolves a real colour per
+tile and keeps eight background palettes live at once — eighteen colours on
+screen where a four-shade palette has four. Rather than switching that off,
+each palette's four rungs are read as a curve indexed by luminance, so
+ADVANCED's variety survives inside the palette's own hue family. Settable to
+TINT, FULL, or OFF for the older four-shade behaviour.
+
+**The frames.** THIN, DOUBLE, TRIPLE, THICK, WIDE, DASH, BEADS and TRACK,
+plus GAME BOY for the engine's own. A border here is six font glyphs, so
+this ships its own glyph page and repoints them.
+
+**What it does not do.** It does not add colours to a scene the Game Boy
+could not draw — four shades is still four shades, these recolour the ramp.
+It changes no gameplay, no data and no save contents. Disable it with one of
+its palettes selected and the game falls back to SGB; you lose the palette,
+never the save.
+
+Lua source and original artwork only: no ROM, no ROM-derived data and no
+game assets. The border sheet is generated from rules in the repository's
+own `tools/make_frames.py`.

--- a/mods/MadeinTaly@groovy_palette/meta.json
+++ b/mods/MadeinTaly@groovy_palette/meta.json
@@ -1,0 +1,28 @@
+{
+  "id": "groovy_palette",
+  "title": "Groovy Palette & Frames",
+  "author": "MadeinTaly",
+  "version": "0.5.0",
+  "categories": [
+    "ART",
+    "UI"
+  ],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-groovy-palette-frames",
+  "github": "MadeinTaly/gen1recomp-groovy-palette-frames",
+  "summary": "Thirty more COLORS palettes and eight text-box borders, previewed on the running game from the COLORS row itself.",
+  "tags": [
+    "palette",
+    "colours",
+    "borders",
+    "cosmetic",
+    "retro"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}

--- a/mods/MadeinTaly@modern_kanto/meta.json
+++ b/mods/MadeinTaly@modern_kanto/meta.json
@@ -2,7 +2,7 @@
   "id": "modern_kanto",
   "title": "Modern Kanto",
   "author": "MadeinTaly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "categories": ["GAMEPLAY", "BALANCE", "UI"],
   "repo": "https://github.com/MadeinTaly/gen1recomp-modern-kanto",
   "github": "MadeinTaly/gen1recomp-modern-kanto",

--- a/mods/MadeinTaly@running_shoes/meta.json
+++ b/mods/MadeinTaly@running_shoes/meta.json
@@ -2,7 +2,7 @@
   "id": "running_shoes",
   "title": "Running Shoes",
   "author": "MadeinTaly",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "categories": ["QOL", "GAMEPLAY"],
   "repo": "https://github.com/MadeinTaly/gen1recomp-running-shoes",
   "github": "MadeinTaly/gen1recomp-running-shoes",


### PR DESCRIPTION
## Changes

**New:**
- `MadeinTaly@groovy_palette` — Groovy Palette & Frames 0.5.0 (thirty more COLORS palettes and eight text-box borders)

**Updated:**
- `MadeinTaly@gen3_box`: 1.2.1 → 1.3.0
- `MadeinTaly@modern_kanto`: 0.1.0 → 0.2.0 (critical: 0.1.0 threw on first line, registered nothing)
- `MadeinTaly@running_shoes`: 1.0.0 → 1.1.0

All four ship Lua source only — no ROM, no ROM-derived data, no game assets.