### PR TITLE
Add Music-FRLG 1.0.0

### DIFF
--- a/mods/DarioMelo@Music-FRLG/description.md
+++ b/mods/DarioMelo@Music-FRLG/description.md
@@ -1,0 +1,1 @@
+Music from FireRed / LeafGreen

--- a/mods/DarioMelo@Music-FRLG/meta.json
+++ b/mods/DarioMelo@Music-FRLG/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "Music-FRLG",
+  "title": "Music-FRLG",
+  "author": "DarioMelo",
+  "version": "1.0.0",
+  "categories": [
+    "AUDIO"
+  ],
+  "repo": "https://github.com/DarioMelo/Gen1Recomp-MusicMods",
+  "tags": [
+    "audio"
+  ],
+  "github": "DarioMelo/Gen1Recomp-MusicMods",
+  "game_version": ">=0.1.59",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/DarioMelo@Music-FRLG/` — **Music-FRLG** 1.0.0 by DarioMelo.

- Source: https://github.com/DarioMelo/Gen1Recomp-MusicMods
- Releases tracked from: `DarioMelo/Gen1Recomp-MusicMods`
- Categories: AUDIO
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>