### PR TITLE
Add madramdesign@exp_share (always-on Exp Share)

### DIFF
--- a/mods/madramdesign@exp_share/description.md
+++ b/mods/madramdesign@exp_share/description.md
@@ -1,0 +1,33 @@
+# Exp Share
+
+Always-on party experience for Gen1Recomp — Gen 6+ Exp Share or classic
+**EXP.ALL** math, without needing Oak's Aide item.
+
+## Modes
+
+| Mode | Behavior |
+| --- | --- |
+| **MODERN** | Full undivided EXP to every living party Pokémon. Needs a build with `BattleState.awardExp` / `battle.exp_award` (newer than 0.1.38). |
+| **CLASSIC** | Gen 1 EXP.ALL share math without the bag item. |
+| **OFF** | Vanilla. |
+
+On **0.1.38** (no `awardExp`), the mod forces classic EXP.ALL so sharing still
+works — bench Pokémon get “with EXP.ALL” messages.
+
+**EXP MESSAGES:** EVERYONE / FIGHTERS / SILENT.
+
+## Install
+
+1. Download `exp_share-1.0.2.zip` from [Releases](https://github.com/madramdesign/gen1recomp-exp-share/releases).
+2. Gen1Recomp → **F10** → **Import mod .zip**.
+3. Enable **Exp Share**, then fully quit and relaunch.
+
+## Compatibility
+
+- Mod API 2, engine `>=0.1.0 <2.0.0`.
+- `content` profile; `affects_link: false`.
+- Stacks fine with Battle EXP Bar (HUD only). Not the same as Pokewalker.
+
+## Credits
+
+madramdesign · MIT

--- a/mods/madramdesign@exp_share/meta.json
+++ b/mods/madramdesign@exp_share/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "exp_share",
+  "title": "Exp Share",
+  "author": "madramdesign",
+  "version": "1.0.2",
+  "categories": ["QOL", "GAMEPLAY"],
+  "repo": "https://github.com/madramdesign/gen1recomp-exp-share",
+  "github": "madramdesign/gen1recomp-exp-share",
+  "summary": "Always-on party Exp Share: modern undivided EXP or classic Gen 1 EXP.ALL math without needing the item.",
+  "tags": ["quality-of-life", "experience", "exp-share", "exp-all", "party"],
+  "permissions": [],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.1.0 <2.0.0",
+  "affects_link": false,
+  "license": "MIT",
+  "automatic_version_check": true
+}


### PR DESCRIPTION
## Summary
- Adds **Exp Share** (`exp_share`) by madramdesign to the community mod index.
- Always-on party EXP: MODERN (undivided) or CLASSIC (Gen 1 EXP.ALL math without the item).
- Source + releases: https://github.com/madramdesign/gen1recomp-exp-share (latest `exp_share-1.0.2.zip`).

## Checklist
- [x] `meta.json` matches manifest (`id`, api 2, content profile, permissions)
- [x] `github` set with `automatic_version_check`
- [x] Release zip at archive root: `exp_share-1.0.2.zip`
- [x] No ROM-derived content


Made with [Cursor](https://cursor.com)