### PR TITLE
Add ShaneMcGovernIE@relearn_moves

### DIFF
--- a/mods/ShaneMcGovernIE@relearn_moves/description.md
+++ b/mods/ShaneMcGovernIE@relearn_moves/description.md
@@ -1,0 +1,25 @@
+# Move Relearn
+
+Lets any POKéMON relearn moves from its species movelist (level-up
+learnset plus level-1 moves) once it has reached the required level — no
+Move Reminder NPC required.
+
+## How it works
+
+1. Open the party menu (START > POKéMON) outside of battle.
+2. Select a POKéMON, then pick **RELEARN** — it sits between STATS and
+   SWITCH.
+3. Choose a move from the list. A free moveset slot learns it right away
+   at full base PP; a full moveset asks which move to forget (HM moves
+   can't be forgotten, same as the level-up flow).
+
+RELEARN always shows in the field party menu — a mon with nothing left to
+relearn reads "No moves to relearn." instead of hiding the row. The battle
+party menu is untouched (SWITCH / STATS / CANCEL).
+
+## Install
+
+1. Download `relearn_moves-1.0.1.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/relearn_moves/releases).
+2. In the game: **MODS > Import mod .zip** and pick the file.
+3. Restart the game. RELEARN appears in every field party-menu submenu.

--- a/mods/ShaneMcGovernIE@relearn_moves/description.md
+++ b/mods/ShaneMcGovernIE@relearn_moves/description.md
@@ -23,3 +23,5 @@ party menu is untouched (SWITCH / STATS / CANCEL).
    [releases page](https://github.com/ShaneMcGovernIE/relearn_moves/releases).
 2. In the game: **MODS > Import mod .zip** and pick the file.
 3. Restart the game. RELEARN appears in every field party-menu submenu.
+Move names too long for the list box scroll as a ticker (hold, scroll,
+hold, scroll back), clipped to the row.

--- a/mods/ShaneMcGovernIE@relearn_moves/meta.json
+++ b/mods/ShaneMcGovernIE@relearn_moves/meta.json
@@ -3,7 +3,7 @@
   "title": "Move Relearn",
   "author": "ShaneMcGovernIE",
   "summary": "Party menu gains RELEARN (between STATS and SWITCH, field only) to relearn any level-up move the mon has reached the level for.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "categories": [
     "GAMEPLAY",
     "QOL"

--- a/mods/ShaneMcGovernIE@relearn_moves/meta.json
+++ b/mods/ShaneMcGovernIE@relearn_moves/meta.json
@@ -1,0 +1,25 @@
+{
+  "id": "relearn_moves",
+  "title": "Move Relearn",
+  "author": "ShaneMcGovernIE",
+  "summary": "Party menu gains RELEARN (between STATS and SWITCH, field only) to relearn any level-up move the mon has reached the level for.",
+  "version": "1.0.1",
+  "categories": [
+    "GAMEPLAY",
+    "QOL"
+  ],
+  "tags": [
+    "party",
+    "moves",
+    "relearn"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/relearn_moves",
+  "github": "ShaneMcGovernIE/relearn_moves",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}

--- a/mods/ShaneMcGovernIE@relearn_moves/meta.json
+++ b/mods/ShaneMcGovernIE@relearn_moves/meta.json
@@ -3,7 +3,7 @@
   "title": "Move Relearn",
   "author": "ShaneMcGovernIE",
   "summary": "Party menu gains RELEARN (between STATS and SWITCH, field only) to relearn any level-up move the mon has reached the level for.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "categories": [
     "GAMEPLAY",
     "QOL"

--- a/mods/ShaneMcGovernIE@relearn_moves/meta.json
+++ b/mods/ShaneMcGovernIE@relearn_moves/meta.json
@@ -3,7 +3,7 @@
   "title": "Move Relearn",
   "author": "ShaneMcGovernIE",
   "summary": "Party menu gains RELEARN (between STATS and SWITCH, field only) to relearn any level-up move the mon has reached the level for.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "categories": [
     "GAMEPLAY",
     "QOL"


### PR DESCRIPTION
Adds the Move Relearn mod to the index: a RELEARN entry in the field party-menu submenu (between STATS and SWITCH) that relearns any level-up move the mon has reached the level for, with a forget list for full movesets (HM moves locked). Battle menu untouched.

- mods/ShaneMcGovernIE@relearn_moves/meta.json + description.md
- validated: node scripts/validate.mjs mods/ShaneMcGovernIE@relearn_moves (0 warnings)
- repo: https://github.com/ShaneMcGovernIE/relearn_moves (automatic_version_check on)