### PR TITLE
Add Shiny Gifts & Starters 1.1.0

### DIFF
--- a/mods/Satori7Kensho@shiny_starters_gifts/description.md
+++ b/mods/Satori7Kensho@shiny_starters_gifts/description.md
@@ -1,0 +1,8 @@
+Force shiny starters and optionally all story gifts in Gen1Recomp. Must activate before receiving Pokémon for shiny.
+
+Options:
+- SHINY STARTERS – Activate before receiving starter to force the player’s starter shiny
+- SHINY ALL GIFTS – makes every story gift (fossils, Lapras, Eevee, etc.) shiny (Activate before receiving gift).
+
+Install by placing the folder in your mods/ directory and enabling it with F10.
+Works alongside the main Shiny Pokémon mod.

--- a/mods/Satori7Kensho@shiny_starters_gifts/meta.json
+++ b/mods/Satori7Kensho@shiny_starters_gifts/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "shiny_starters_gifts",
+  "title": "Shiny Gifts & Starters",
+  "author": "Satori7Kensho",
+  "version": "1.1.0",
+  "categories": [
+    "ART",
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/Satori7Kensho/gen1recomp-shiny-starters-gifts",
+  "tags": [
+    "qol",
+    "shiny",
+    "gift",
+    "shiny starters",
+    "shiny gifts"
+  ],
+  "github": "Satori7Kensho/gen1recomp-shiny-starters-gifts",
+  "license": "MIT",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Satori7Kensho@shiny_starters_gifts/` — **Shiny Gifts & Starters** 1.1.0 by Satori7Kensho.

- Source: https://github.com/Satori7Kensho/gen1recomp-shiny-starters-gifts
- Releases tracked from: `Satori7Kensho/gen1recomp-shiny-starters-gifts`
- Categories: ART, UI, QOL
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>