### PR TITLE
Add Traduction FR étendue 0.1.0

### DIFF
--- a/mods/AntoniMan31@trad-fr-extended/description.md
+++ b/mods/AntoniMan31@trad-fr-extended/description.md
@@ -1,0 +1,2 @@
+> **Ce mod ne fonctionne pas seul.** Il complète `translation-fr` et exige
+> qu'il soit installé et activé.

--- a/mods/AntoniMan31@trad-fr-extended/meta.json
+++ b/mods/AntoniMan31@trad-fr-extended/meta.json
@@ -1,0 +1,27 @@
+{
+  "id": "trad-fr-extended",
+  "title": "Traduction FR étendue",
+  "author": "AntoniMan31",
+  "version": "0.1.0",
+  "categories": [
+    "UI",
+    "TRANSLATION"
+  ],
+  "repo": "https://github.com/antoniman31/trad-fr-extended",
+  "summary": "Complète la traduction française de translation-fr : 151 catégories du Pokédex, 109 textes moteur et 11 noms manquants. Nécessite translation-fr.",
+  "tags": [
+    "francais",
+    "traduction",
+    "french",
+    "pokedex",
+    "overlay",
+    "texte"
+  ],
+  "github": "antoniman31/trad-fr-extended",
+  "downloadURL": "https://github.com/antoniman31/trad-fr-extended/releases/download/v0.1.0/trad-fr-extended-0.1.0.zip",
+  "dependencies": [
+    "translation-fr"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/AntoniMan31@trad-fr-extended/` — **Traduction FR étendue** 0.1.0 by AntoniMan31.

- Source: https://github.com/antoniman31/trad-fr-extended
- Releases tracked from: `antoniman31/trad-fr-extended`
- Categories: UI, TRANSLATION
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>