### PR TITLE
Add Music-HGSS 26.08.04

### DIFF
--- a/mods/DarioMelo@Music_HGSS/description.md
+++ b/mods/DarioMelo@Music_HGSS/description.md
@@ -1,0 +1,1 @@
+Music from HeartGold / SoulSilver

--- a/mods/DarioMelo@Music_HGSS/meta.json
+++ b/mods/DarioMelo@Music_HGSS/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "Music_HGSS",
+  "title": "Music-HGSS",
+  "author": "DarioMelo",
+  "version": "26.08.04",
+  "categories": [
+    "AUDIO"
+  ],
+  "repo": "https://github.com/DarioMelo/Gen1Recomp-MusicMods",
+  "tags": [
+    "audio",
+    "music"
+  ],
+  "github": "DarioMelo/Gen1Recomp-MusicMods",
+  "game_version": ">=0.1.68",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/DarioMelo@Music_HGSS/` — **Music-HGSS** 26.08.04 by DarioMelo.

- Source: https://github.com/DarioMelo/Gen1Recomp-MusicMods
- Releases tracked from: `DarioMelo/Gen1Recomp-MusicMods`
- Categories: AUDIO
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>