### PR TITLE
Add PokéPC Followers (W/Voxel Support) 0.0.5

### DIFF
--- a/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/description.md
+++ b/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/description.md
@@ -1,0 +1,1 @@
+An all-species overworld follower mod for Pokémon Red, Blue, and Yellow (Gen 1 Recomp). This mod allows every single Gen 1 Pokémon to walk behind you in full overworld color as your companion!

--- a/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/meta.json
+++ b/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "PokePCFollowers_VoxelMerge",
+  "title": "PokéPC Followers (W/Voxel Support)",
+  "author": "Gamecorner_033",
+  "version": "0.0.5",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT",
+    "ART",
+    "LIBRARY"
+  ],
+  "repo": "https://github.com/gamecorner-033/PokePCFollowers",
+  "github": "gamecorner-033/PokePCFollowers",
+  "downloadURL": "https://github.com/gamecorner-033/PokePCFollowers/releases/download/v0.0.5/mod.zip",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Gamecorner_033@PokePCFollowers_VoxelMerge/` — **PokéPC Followers (W/Voxel Support)** 0.0.5 by Gamecorner_033.

- Source: https://github.com/gamecorner-033/PokePCFollowers
- Releases tracked from: `gamecorner-033/PokePCFollowers`
- Categories: GAMEPLAY, CONTENT, ART, LIBRARY
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>