### PR TITLE
Add Kanto Companion Lite 1.3.0

### DIFF
--- a/mods/redelpedron@kanto_companion_lite/description.md
+++ b/mods/redelpedron@kanto_companion_lite/description.md
@@ -1,0 +1,11 @@
+# Kanto Companion Lite
+
+An in-game companion that loads directly on top of the game to enhance my playthrough. Android fork of matthew.me Kanto Companion
+
+Every control is a touch button, drag, or tap — there are no keyboard shortcuts and no mouse-wheel dependencies.
+
+## Install
+
+1. Download `Kanto.Companion.Lite.zip` from the
+   [releases page](https://github.com/redelpedron/Kanto-Companion-Lite/releases).
+2. In the launcher: MODS → **Import mod .zip**.

--- a/mods/redelpedron@kanto_companion_lite/meta.json
+++ b/mods/redelpedron@kanto_companion_lite/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "kanto_companion_lite",
+  "title": "Kanto Companion Lite",
+  "author": "redelpedron",
+  "version": "1.3.0",
+  "categories": [
+    "QOL"
+  ],
+  "repo": "https://github.com/redelpedron/Kanto-Companion-Lite",
+  "summary": "A stripped-down fork of Kanto Companion by @matthew.me, redesigned for Android. Keyboard shortcuts have been replaced with touch controls for a mobile-friendly experience while retaining the companion",
+  "github": "redelpedron/Kanto-Companion-Lite",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/redelpedron@kanto_companion_lite/` — **Kanto Companion Lite** 1.4.0 by redelpedron.

- Source: https://github.com/redelpedron/Kanto-Companion-Lite
- Releases tracked from: `redelpedron/Kanto-Companion-Lite`
- Categories: QOL
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>