### PR TITLE
Add Overworld Wild Encounters 0.0.5

### DIFF
--- a/mods/Gamecorner_033@overworld_encounters/description.md
+++ b/mods/Gamecorner_033@overworld_encounters/description.md
@@ -1,0 +1,9 @@
+Replaces hidden random grass encounters with visible roaming overworld Pokémon sprites!
+
+Features:
+- Visible 3D & 2D roaming Pokémon (4-5 on small routes, 5-8 on large routes & caves).
+- Authentic Kanto species dispersal for all 151 Gen 1 species (excluding legendaries).
+- Biome-specific species (Caves, Water, Grass, Forests).
+- Dynamic Time-of-Day rotation (MORN, DAY, NITE).
+- 100% Voxel 3D & Follower Mod compatible.
+- Modular architecture ready for Gen 2.

--- a/mods/Gamecorner_033@overworld_encounters/meta.json
+++ b/mods/Gamecorner_033@overworld_encounters/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "overworld_encounters",
+  "title": "Overworld Wild Encounters",
+  "author": "Gamecorner_033",
+  "version": "0.0.5",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT",
+    "ART",
+    "LIBRARY"
+  ],
+  "repo": "https://github.com/gamecorner-033/Gen1PC-OverworldEncounters",
+  "github": "gamecorner-033/Gen1PC-OverworldEncounters",
+  "downloadURL": "https://github.com/gamecorner-033/Gen1PC-OverworldEncounters/releases/download/v0.0.5/overworld_encounters.zip",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Gamecorner_033@overworld_encounters/` — **Overworld Wild Encounters** 0.0.5 by Gamecorner_033.

- Source: https://github.com/gamecorner-033/Gen1PC-OverworldEncounters
- Releases tracked from: `gamecorner-033/Gen1PC-OverworldEncounters`
- Categories: GAMEPLAY, CONTENT, ART, LIBRARY
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>