### PR TITLE
Add gen1-kr 0.1.0

### DIFF
--- a/mods/adrian@gen1_kr/description.md
+++ b/mods/adrian@gen1_kr/description.md
@@ -1,0 +1,1 @@
+KITT outdoor driving mod for gen1recomp.

--- a/mods/adrian@gen1_kr/meta.json
+++ b/mods/adrian@gen1_kr/meta.json
@@ -1,0 +1,23 @@
+{
+  "id": "gen1_kr",
+  "title": "gen1-kr",
+  "author": "adrian",
+  "version": "0.1.0",
+  "categories": [
+    "GAMEPLAY",
+    "AUDIO",
+    "OTHER"
+  ],
+  "repo": "https://github.com/castdrian/gen1-kr",
+  "tags": [
+    "knight rider",
+    "kitt"
+  ],
+  "github": "castdrian/gen1-kr",
+  "conflicts": [
+    "DRAMATIC_SHAPE"
+  ],
+  "api": 2,
+  "profile": "content",
+  "experimental": true
+}


### PR DESCRIPTION
Adds `mods/adrian@gen1_kr/` — **gen1-kr** 0.1.0 by adrian.

- Source: https://github.com/castdrian/gen1-kr
- Releases tracked from: `castdrian/gen1-kr`
- Categories: GAMEPLAY, AUDIO, OTHER
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>