### PR TITLE
Sync MadeinTaly mods: add Gen 3 Dex, update Gen 3 Box

### DIFF
--- a/mods/MadeinTaly@gen3_box/meta.json
+++ b/mods/MadeinTaly@gen3_box/meta.json
@@ -2,7 +2,7 @@
   "id": "gen3_box",
   "title": "Gen 3 Box",
   "author": "MadeinTaly",
-  "version": "1.3.0",
+  "version": "1.5.2",
   "categories": ["UI", "QOL"],
   "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-boxes",
   "github": "MadeinTaly/gen1recomp-gen3-boxes",

--- a/mods/MadeinTaly@gen3_dex/description.md
+++ b/mods/MadeinTaly@gen3_dex/description.md
@@ -1,0 +1,32 @@
+The Pokédex as a **grid of pictures** instead of a list of names.
+
+The engine's own dex list describes itself accurately: a dex-ordered list of
+151 text rows with seen/owned markers. This replaces that list with a 5×4
+grid of battle pictures, and shows three states at a glance — species you
+**own** are drawn in their own colours, ones you have **seen but not
+caught** are dimmed, and ones you have never met are blanks.
+
+**Colour.** A palette zone binds a palette to a tile rectangle, and the
+engine draws each one scissored through its shade-remap shader, so the
+number of them is a loop rather than a hardware limit: the Game Boy could
+show four palettes at once, and this shows twenty-one.
+
+**Filters.** SELECT cycles ALL / OWNED / MISSING / SEEN ONLY. MISSING is
+the fastest answer to what you are still short of.
+
+**It does not replace the species page.** Pressing A opens the engine's own
+`DexEntryMenu`, so a mod that adds pages there — Useful Dex, for instance —
+keeps working, and its pages are one press further in. The two stack rather
+than conflict.
+
+**GRID BIG** asks the renderer for a 320×288 surface, which is what lets a
+56×56 battle picture draw at scale 1 rather than halved. GRID CLASSIC keeps
+the Game Boy screen, in greyscale: a 28-pixel cell is three and a half
+tiles and a palette zone must be tile-aligned.
+
+**What it does not do:** it does not make the Pokémon sharper — the
+pictures are the game's own art and cannot be redrawn, so the larger
+surface buys room and colour, never detail. It reads the save's dex and
+writes nothing.
+
+Lua source only: no ROM, no ROM-derived data and no game assets.

--- a/mods/MadeinTaly@gen3_dex/meta.json
+++ b/mods/MadeinTaly@gen3_dex/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "gen3_dex",
+  "title": "Gen 3 Dex",
+  "author": "MadeinTaly",
+  "version": "0.1.0",
+  "categories": ["UI", "ART"],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-dex",
+  "github": "MadeinTaly/gen1recomp-gen3-dex",
+  "summary": "The Pokedex as a grid of pictures, each owned species in its own colours, with ALL/OWNED/MISSING filters.",
+  "tags": ["pokedex", "ui", "grid", "cosmetic", "qol"],
+  "permissions": ["engine_internals"],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}


### PR DESCRIPTION
## Changes

- **Gen 3 Dex** `0.1.0` — **new**
  The Pokédex as a 5×4 grid of battle pictures. Each owned species draws in its own colours; seen-but-not-caught are dimmed; never-met are blank. SELECT cycles ALL / OWNED / MISSING / SEEN ONLY filters. Pressing A opens the engine's own `DexEntryMenu`, so mods that add pages there (e.g. Useful Dex) keep working.

- **Gen 3 Box** `1.3.0` → `1.5.2` — **updated**
  Adds BOX HEALS and a 320×288 grid with a per-Pokémon palette.

## Notes

Both mods ship Lua source only — no ROM, no ROM-derived data, no game assets. Releases are published by CI as `<id>-<version>.zip`.