### PR TITLE
fix: correct Gen1 KR dependency metadata

### DIFF
--- a/mods/adrian@gen1_kr/description.md
+++ b/mods/adrian@gen1_kr/description.md
@@ -1,1 +1,3 @@
-KITT outdoor driving mod for gen1recomp.
+Drive KITT across Kanto in 3D.
+
+Requires Dramatic Shape Voxel Mod.

--- a/mods/adrian@gen1_kr/meta.json
+++ b/mods/adrian@gen1_kr/meta.json
@@ -1,8 +1,9 @@
 {
   "id": "gen1_kr",
-  "title": "gen1-kr",
+  "title": "Gen1 KR",
   "author": "adrian",
-  "version": "0.1.0",
+  "summary": "Drive KITT across Kanto.",
+  "version": "0.2.0",
   "categories": [
     "GAMEPLAY",
     "AUDIO",
@@ -14,10 +15,14 @@
     "kitt"
   ],
   "github": "castdrian/gen1-kr",
-  "conflicts": [
-    "DRAMATIC_SHAPE"
+  "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
+  "permissions": [
+    "engine_internals"
   ],
+  "dependencies": [
+    "DRAMATIC_SHAPE@>=1.6.0 <2.0.0"
+  ],
+  "conflicts": [],
   "api": 2,
-  "profile": "content",
-  "experimental": true
+  "profile": "content"
 }


### PR DESCRIPTION
Updates the Gen1 KR listing for the 0.2.0 release.

- declares Dramatic Shape Voxel Mod 1.6.0+ as a dependency

Validated with `node scripts/validate.mjs mods/adrian@gen1_kr`.