### PR TITLE
Add Auto Battle by eduardocalafell

### DIFF
--- a/mods/eduardocalafell@auto_battle/description.md
+++ b/mods/eduardocalafell@auto_battle/description.md
@@ -1,0 +1,30 @@
+# Auto Battle
+
+Let the game fight for you. When **Auto Battle** is on, your move is chosen each
+turn instead of the FIGHT menu opening — and a small on-screen badge shows it's
+active.
+
+## Features
+
+- **Smart move picking.** Scores every usable move by
+  `power × type-effectiveness × STAB` against the current foe and uses the best
+  one. When nothing lands effectively (only status moves, or the foe is immune),
+  it falls back to the game's own NPC move picker.
+- **Skip dialogs (optional).** Fast-forwards battle text so turns fly by — while
+  never auto-confirming YES/NO prompts, move-learning, evolution, or the
+  party/bag menus.
+- **Stay in control.** A short takeover window lets you nudge the D-pad to open
+  the menu yourself that turn: switch, use an item, run, or catch.
+- **Clear UI.** `AUTO` / `SKIP` tags in the corner show what's on, plus the name
+  of the move it just used.
+
+## Options
+
+- **AUTO BATTLE** — ON / OFF (default OFF)
+- **TAKEOVER WINDOW** — INSTANT / FAST / RELAXED
+- **SKIP DIALOGS** — ON / OFF (default OFF)
+
+For the fastest battles, pair both toggles with battle animations turned off in
+the game options.
+
+MIT licensed. You supply your own ROM; nothing ROM-derived is included.

--- a/mods/eduardocalafell@auto_battle/meta.json
+++ b/mods/eduardocalafell@auto_battle/meta.json
@@ -3,7 +3,7 @@
   "title": "Auto Battle",
   "author": "eduardocalafell",
   "summary": "Auto-picks the most type-effective move each turn (falls back to the NPC AI), with an optional dialog skip and on-screen AUTO/SKIP badges.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "categories": ["GAMEPLAY", "QOL", "UI"],
   "tags": ["battle", "auto", "qol", "ui"],
   "repo": "https://github.com/eduardocalafell/gen1recomp-auto-battle",

--- a/mods/eduardocalafell@auto_battle/meta.json
+++ b/mods/eduardocalafell@auto_battle/meta.json
@@ -3,7 +3,7 @@
   "title": "Auto Battle",
   "author": "eduardocalafell",
   "summary": "Auto-picks the most type-effective move each turn (falls back to the NPC AI), with an optional dialog skip and on-screen AUTO/SKIP badges.",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "categories": ["GAMEPLAY", "QOL", "UI"],
   "tags": ["battle", "auto", "qol", "ui"],
   "repo": "https://github.com/eduardocalafell/gen1recomp-auto-battle",

--- a/mods/eduardocalafell@auto_battle/meta.json
+++ b/mods/eduardocalafell@auto_battle/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "auto_battle",
+  "title": "Auto Battle",
+  "author": "eduardocalafell",
+  "summary": "Auto-picks the most type-effective move each turn (falls back to the NPC AI), with an optional dialog skip and on-screen AUTO/SKIP badges.",
+  "version": "0.1.0",
+  "categories": ["GAMEPLAY", "QOL", "UI"],
+  "tags": ["battle", "auto", "qol", "ui"],
+  "repo": "https://github.com/eduardocalafell/gen1recomp-auto-battle",
+  "github": "eduardocalafell/gen1recomp-auto-battle",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.37 <2.0.0",
+  "profile": "content",
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds `mods/eduardocalafell@auto_battle/`.

Auto Battle auto-picks the most type-effective move each turn (falls back to the game's NPC AI when nothing lands), with an optional dialog-skip and on-screen AUTO/SKIP badges. Skip only advances plain battle text — it never auto-confirms YES/NO, move-learn, or evolution prompts.

- Repo: https://github.com/eduardocalafell/gen1recomp-auto-battle
- Release v0.1.0 with the installable zip (files at the archive root).
- `node scripts/validate.mjs mods/eduardocalafell@auto_battle` passes (0 warnings).
- meta.json id/api/profile/permissions/dependencies/conflicts match the mod's manifest.json.
- MIT; nothing ROM-derived is distributed.