### PR TITLE
add: critical_capture, useful_marts, mods_hotkeys (ShaneMcGovernIE)

### DIFF
--- a/mods/ShaneMcGovernIE@critical_capture/description.md
+++ b/mods/ShaneMcGovernIE@critical_capture/description.md
@@ -1,0 +1,38 @@
+# Critical Capture
+
+Gen 5's critical capture for the Gen 1 recomp: a thrown ball can go
+critical — a rising whistle, a mid-air pause and shudder, then a single
+decisive shake with far better odds than the vanilla three-wobble check.
+The chance scales with your Pokedex completion, rescaled from the modern
+600+ species to Gen 1's 151.
+
+## How it works
+
+1. Install the mod and enable it in the mod manager (MODS row in OPTIONS).
+2. Throw balls at wild Pokemon. Early on, almost nothing goes critical; the
+   more species you have registered as owned, the more often it happens.
+3. A critical capture whistles, the ball pauses and shudders at the top of
+   its arc, and it shakes exactly once before the Pokemon is caught — or
+   breaks free.
+4. OPTIONS > CRIT CAPTURE cycles **OFF / GEN 5 / GEN 6**. GEN 5 uses the
+   cube root of the catch chance for the decisive shake; GEN 6 uses the
+   fourth root (critical captures are more effective, exactly as in the
+   modern games). **OFF** restores vanilla catching exactly.
+
+The chance is Bulbapedia's Gen 5 model: `c = floor(a * multiplier / 6)`,
+rolled as `rng(0,255) < c`, where `a` is the modified catch rate on a
+0-255 scale. Since Gen 1's two-roll algorithm never computes an `a`, the
+mod uses the exact probability of the throw (the rate roll and the HP roll
+combined) scaled to 0-255 — so the critical chance tracks the real odds of
+the ball. The multiplier ladder is Gen 5's, rescaled to the 151-species
+dex and split into quarter steps, from 2.5 at a complete dex down to 0 for
+0-15 species caught.
+
+## Install
+
+1. Download `critical_capture-0.1.1.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/critical_capture/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/critical_capture"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@critical_capture/meta.json
+++ b/mods/ShaneMcGovernIE@critical_capture/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "critical_capture",
+  "title": "Critical Capture",
+  "author": "ShaneMcGovernIE",
+  "version": "0.1.1",
+  "categories": [
+    "GAMEPLAY"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/critical_capture",
+  "summary": "Gen 5's critical capture: a thrown ball can whistle, pause and shudder mid-air, then shake once with far better odds, scaled with your Pokedex completion.",
+  "tags": [
+    "catch",
+    "capture",
+    "ball",
+    "pokedex"
+  ],
+  "github": "ShaneMcGovernIE/critical_capture",
+  "automatic_version_check": true,
+  "api": 2,
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}

--- a/mods/ShaneMcGovernIE@mods_hotkeys/description.md
+++ b/mods/ShaneMcGovernIE@mods_hotkeys/description.md
@@ -1,0 +1,37 @@
+# Mods Hotkeys
+
+Detects the hotkeys other installed mods listen for — and the engine's own
+built-in ones — and lets you rebind them from OPTIONS -> MODS HOTKEYS,
+multi-button combos included (SELECT + A, TAB + LB).
+
+## What it does
+
+- Scans every enabled mod's Lua sources for the input idioms mods actually
+  use: wrapped `keypressed` key checks (`key == "q"`), wrapped
+  `gamepadpressed` button checks (`button == "leftshoulder"`), held
+  pad-button combos (`held.back and held.leftshoulder`), GB-button combos
+  (`wasPressed("select") and wasPressed("a")`), configurable GB-button
+  triggers, and direct keyboard polls — each with an edge latch.
+- Includes the engine's built-in hotkeys when the running build has them:
+  game speed via the `1` key and the L2/R2 bumpers (SPEED UP / SPEED DOWN
+  rows, rebound like any mod hotkey).
+- Each distinct trigger becomes a row on one of two pages — OPTIONS -> PC
+  HOTKEYS (keyboard triggers) and OPTIONS -> PAD HOTKEYS (controller
+  triggers) — showing the current trigger (e.g. `Q`, `LB+BACK`, `R2`,
+  `SELECT+A`).
+- A rebinds a row: press your new combo (any mix of keyboard keys and pad
+  buttons), release to set. Escape cancels. SELECT resets one row, START
+  resets everything.
+- Rebinds persist in options.lua, so they survive NEW GAME, CONTINUE and
+  quitting.
+- Mod names longer than the row's label window scroll as a ticker, so long
+  names stay readable instead of bleeding over the box border.
+
+## Install
+
+1. Download `mods_hotkeys-0.1.10.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/mods_hotkeys/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/mods_hotkeys"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@mods_hotkeys/meta.json
+++ b/mods/ShaneMcGovernIE@mods_hotkeys/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "mods_hotkeys",
+  "title": "Mods Hotkeys",
+  "author": "ShaneMcGovernIE",
+  "version": "0.1.10",
+  "categories": [
+    "QOL",
+    "TOOL"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/mods_hotkeys",
+  "summary": "Detects the hotkeys other installed mods listen for (and the engine's built-ins) and lets you rebind them from OPTIONS, multi-button combos included.",
+  "tags": [
+    "hotkeys",
+    "rebind",
+    "options",
+    "keyboard",
+    "controller"
+  ],
+  "github": "ShaneMcGovernIE/mods_hotkeys",
+  "automatic_version_check": true,
+  "api": 2,
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}

--- a/mods/ShaneMcGovernIE@useful_marts/description.md
+++ b/mods/ShaneMcGovernIE@useful_marts/description.md
@@ -1,0 +1,37 @@
+# Useful Marts
+
+In the Poke Mart, every list row gains a second, right-aligned line, and
+the lists wrap at the ends:
+
+- **BUY**: how many of that item you already have in the bag ("×N in
+  bag"), under the item name and its ¥ buy price. The count updates
+  immediately as you buy.
+- **SELL**: the item's per-item sell price (half the buy price), under the
+  item name and its usual "xN" count.
+- **Wrap**: Up on the first row jumps to the last, Down on the last row
+  jumps to the first, on both lists.
+
+## How to try it
+
+1. Install the mod zip in the launcher, or drop the folder into the game's
+   `mods/` directory and enable it.
+2. Talk to a mart clerk.
+3. On BUY, each item shows how many you own (and it tracks your purchases);
+   on SELL, each sellable item shows its ¥ sell price beneath the name and
+   count. Key items and HMs (which cannot be sold) show neither price,
+   exactly as vanilla.
+
+## Notes
+
+- Sell price matches the engine's: half the buy price, rounded down.
+- The bag, the PC, and every other list are unchanged; the quantity box
+  and the "I can pay you" confirmation still work as vanilla.
+
+## Install
+
+1. Download `useful_marts-1.0.1.zip` from the
+   [releases page](https://github.com/ShaneMcGovernIE/useful-marts/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "ShaneMcGovernIE/useful-marts"` set, the launcher's
+**Update** and **Versions** buttons handle new releases from there.

--- a/mods/ShaneMcGovernIE@useful_marts/meta.json
+++ b/mods/ShaneMcGovernIE@useful_marts/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "useful_marts",
+  "title": "Useful Marts",
+  "author": "ShaneMcGovernIE",
+  "version": "1.0.1",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/useful-marts",
+  "summary": "Mart lists with useful info: BUY rows show how many of each item you already have (live), SELL rows show the per-item sell price, and both lists wrap at the ends.",
+  "tags": [
+    "mart",
+    "shop",
+    "items",
+    "prices"
+  ],
+  "github": "ShaneMcGovernIE/useful-marts",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
+}


### PR DESCRIPTION
**Mod:** Critical Capture 0.1.1, Useful Marts 1.0.1, Mods Hotkeys 0.1.10 — ShaneMcGovernIE
**Folder:** `mods/ShaneMcGovernIE@critical_capture/`, `mods/ShaneMcGovernIE@useful_marts/`, `mods/ShaneMcGovernIE@mods_hotkeys/`
**Source:** https://github.com/ShaneMcGovernIE/critical_capture · https://github.com/ShaneMcGovernIE/useful-marts · https://github.com/ShaneMcGovernIE/mods_hotkeys

- [x] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/<Author>@<id>/`