### PR TITLE
Add MrJoufflu@translation-qc (Traduction Quebecoise)

### DIFF
--- a/mods/MrJoufflu@translation-qc/description.md
+++ b/mods/MrJoufflu@translation-qc/description.md
@@ -1,0 +1,30 @@
+# Traduction Québécoise
+
+Une traduction complète en français québécois pour Pokémon Rouge, Bleu et Jaune.
+
+Basée sur le vrai texte français officiel du jeu (aucune traduction automatique),
+avec du vocabulaire joual, des sacres québécois ciblés sur les moments dramatiques
+(Team Rocket, le rival, Giovanni), et les noms de villes remplacés par de vraies
+villes du Québec (Montréal, Rimouski, Val-Jalbert, Thetford Mines, Percé,
+Baie-Comeau, Baie-Saint-Paul, Laval, Tadoussac, Mont-Tremblant, Québec).
+
+## Ce qui est traduit
+
+- Tout le dialogue du jeu (PNJ, combats, menus, Pokédex)
+- Les noms d'objets, d'attaques et d'espèces (terminologie française officielle)
+- Les noms de personnages adaptés en québécois (ex. PROF. OAK devient PROF. TREMBLAY)
+- Les noms de villes
+
+Certains caractères accentués ne s'affichent pas correctement en jeu (limitation
+de la police vanilla), donc le texte est volontairement sans accents.
+
+## Install
+
+1. Télécharge le dernier `.zip` depuis la
+   [page des releases](https://github.com/git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC/releases).
+2. Dans le launcher: MODS → **Import mod .zip**.
+
+Avec `"github": "git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC"` configuré, les boutons
+**Update** et **Versions** du launcher gèrent les nouvelles releases automatiquement.
+
+Créé par [MrJoufflu](https://twitch.tv/mrjoufflu) ([mrjoufflu.com](https://mrjoufflu.com)).

--- a/mods/MrJoufflu@translation-qc/meta.json
+++ b/mods/MrJoufflu@translation-qc/meta.json
@@ -1,0 +1,22 @@
+{
+  "id": "translation-qc",
+  "title": "Traduction Québécoise",
+  "author": "MrJoufflu",
+  "summary": "Traduction complète en français québécois (joual + sacres ciblés) pour Pokémon Rouge, Bleu et Jaune, basée sur le texte français officiel.",
+  "version": "1.0.1",
+  "categories": [
+    "TRANSLATION"
+  ],
+  "tags": [
+    "quebecois",
+    "french",
+    "translation",
+    "traduction",
+    "joual"
+  ],
+  "repo": "https://github.com/git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC",
+  "github": "git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC",
+  "api": 2,
+  "game_version": ">=0.0.0-dev",
+  "profile": "content"
+}


### PR DESCRIPTION
Ajoute la traduction quebecoise (francais officiel + joual + sacres cibles) pour Pokemon Rouge/Bleu/Jaune.\n\nRepo: https://github.com/git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC\nReleases: https://github.com/git-mrjoufflu/pokemon-gen1-recomp-mod-FRQC/releases