### PR TITLE
Add Bag Sort by eduardocalafell

### DIFF
--- a/mods/eduardocalafell@bag_sort/description.md
+++ b/mods/eduardocalafell@bag_sort/description.md
@@ -1,0 +1,41 @@
+# Bag Sort
+
+Sort your bag with one button. Open the bag and press **START** to cycle through
+sort orders; the current order shows at the top-right.
+
+## Sort orders
+
+- **NAME** — alphabetical
+- **QTY** — most of an item first
+- **TYPE** — grouped: Poké Balls → HP medicine → stones → other → TMs → HMs →
+  key items (alphabetical within each group)
+- **RECENT** — most recently obtained first
+- **OLDEST** — original acquisition order (the game's default)
+
+The sort is **persistent** — it reorders the real bag order (`save.bagOrder`),
+exactly like the game's own SELECT swap, so it sticks across sessions. Newly
+obtained items land at the end until you sort again. Works both in the field and
+in battle.
+
+## Install
+
+1. Download `bag_sort-0.1.0.zip` from the releases page.
+2. In the launcher, MODS → **Import mod .zip**.
+3. Enable it, open the bag, and press START.
+
+## How it works
+
+- The bag list is built from `Bag.order(save)` — an array of item ids. Sorting
+  reorders that array in place.
+- The mod wraps `BagMenu.new` read-only to attach a START handler + indicator to
+  the `ListMenu` it returns (`ListMenu:update` leaves START unused).
+- RECENT/OLDEST use an acquisition index recorded per item id in the mod's save.
+
+## Compatibility
+
+- Mod API 2, engine `>=0.1.37`, `content` profile (link play unaffected).
+- Touches only the bag UI; no conflicts expected.
+
+## Credits
+
+Made by eduardocalafell. MIT licensed.

--- a/mods/eduardocalafell@bag_sort/meta.json
+++ b/mods/eduardocalafell@bag_sort/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "bag_sort",
+  "title": "Bag Sort",
+  "author": "eduardocalafell",
+  "summary": "Sort your bag by name, quantity, type, or how recently you got each item.",
+  "version": "0.1.0",
+  "categories": ["QOL", "UI"],
+  "tags": ["bag", "inventory", "sort", "items"],
+  "repo": "https://github.com/eduardocalafell/gen1recomp-bag-sort",
+  "github": "eduardocalafell/gen1recomp-bag-sort",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.37 <2.0.0",
+  "profile": "content",
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds `mods/eduardocalafell@bag_sort/`.

**Bag Sort** — press START in the bag to cycle sort orders: NAME, QTY, TYPE
(balls → HP medicine → stones → other → TMs → HMs → key items), RECENT, OLDEST.
The current order shows top-right.

- Reorders `save.bagOrder` in place (persistent, like the game's SELECT swap),
  via a read-only wrap of `BagMenu.new` + the returned `ListMenu` (`update`
  leaves START unused). RECENT/OLDEST use a per-item acquisition index in the
  mod's save.
- Mod API 2, `content` profile, `engine_internals` only. No ROM-derived content.
- Repo: https://github.com/eduardocalafell/gen1recomp-bag-sort (v0.1.0 release,
  zip at the archive root).

`node scripts/validate.mjs mods/eduardocalafell@bag_sort` passes.