### PR TITLE
Add Minimap by eduardocalafell

### DIFF
--- a/mods/eduardocalafell@minimap/description.md
+++ b/mods/eduardocalafell@minimap/description.md
@@ -1,0 +1,25 @@
+# Minimap
+
+Press **M** in the overworld to open a schematic **minimap** of the map you're
+on — see the whole layout at a glance without leaving the field.
+
+## Shows
+
+- **Walls vs. paths**, **tall grass**, **water**, and **exits / warps**
+  (doors, connections, ledges out).
+- A **blinking marker** on your position.
+- The current **map's name** up top (e.g. `ROUTE 1`).
+
+## Use
+
+- **M** toggles it on/off while walking.
+- It only appears in the overworld, so it never covers menus, dialogue, or
+  battle — and **M** does nothing there.
+
+## Options
+
+- **MAP SIZE** — SMALL / MEDIUM / LARGE
+- **SHOW BY DEFAULT** — start with the minimap open instead of pressing M first.
+
+Drawn over the field HUD in crisp native pixels, reading the live map grid — so
+it stays accurate as you walk, surf, and enter buildings.

--- a/mods/eduardocalafell@minimap/meta.json
+++ b/mods/eduardocalafell@minimap/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "minimap",
+  "title": "Minimap",
+  "author": "eduardocalafell",
+  "summary": "A toggleable overworld minimap (press M): walls, paths, grass, water and exits, with your position and the map's name.",
+  "version": "0.1.0",
+  "categories": ["UI", "QOL"],
+  "tags": ["minimap", "map", "overworld", "ui", "qol"],
+  "repo": "https://github.com/eduardocalafell/gen1recomp-minimap",
+  "github": "eduardocalafell/gen1recomp-minimap",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.37 <2.0.0",
+  "profile": "content",
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds `mods/eduardocalafell@minimap/`.

A toggleable overworld minimap (press M): a schematic of the current map — walls, paths, tall grass, water and exits — with a blinking marker on the player and the map's name. Overworld-only (hides in menus/dialogue/battle). SMALL/MEDIUM/LARGE size option.

- Repo: https://github.com/eduardocalafell/gen1recomp-minimap
- Release v0.1.0 with the installable zip (files at the archive root).
- `node scripts/validate.mjs mods/eduardocalafell@minimap` passes (0 warnings).
- meta.json id/api/profile/permissions/dependencies/conflicts match the mod's manifest.json.
- MIT; nothing ROM-derived is distributed.