### PR TITLE
Add Fakémons by eduardocalafell

### DIFF
--- a/mods/eduardocalafell@fakemons/description.md
+++ b/mods/eduardocalafell@fakemons/description.md
@@ -1,0 +1,22 @@
+# Fakémons
+
+Original, fan-made **Fakémons** added to Kanto as **real, catchable species** —
+not sprite swaps. Each has its own base stats, types, level-up learnset, TM/HM
+compatibility, Pokédex entry and **original art**, and lives in a themed wild
+habitat. Once caught it behaves like any Pokémon: party, box, Pokédex, IVs,
+stats and battle all run through the game's own systems.
+
+All art is created for this mod — nothing is ripped or ROM-derived.
+
+## Current roster
+
+- **CINDRAKE** (#152) — the *Ember Drake*, a **Fire / Dragon** hatchling. Fast
+  and offensive; learns Ember → Dragon Rage → Slash → Flamethrower → Swords
+  Dance → Fire Blast → Hyper Beam. Found in the **Pokémon Mansion** on Cinnabar
+  Island (Lv 28–36).
+
+More creatures will be added over time — the mod is built to grow.
+
+## Options
+
+- **FAKEMONS** — ON / OFF (toggles the wild spawns).

--- a/mods/eduardocalafell@fakemons/meta.json
+++ b/mods/eduardocalafell@fakemons/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "fakemons",
+  "title": "Fakémons",
+  "author": "eduardocalafell",
+  "summary": "Original fan-made Fakémons as real catchable species — full stats, moves, learnsets, dex entries and original art, spawning in themed habitats.",
+  "version": "0.1.0",
+  "categories": ["CONTENT", "GAMEPLAY"],
+  "tags": ["fakemon", "pokemon", "species", "content"],
+  "repo": "https://github.com/eduardocalafell/gen1recomp-fakemons",
+  "github": "eduardocalafell/gen1recomp-fakemons",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.37 <2.0.0",
+  "profile": "content",
+  "permissions": [],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}

--- a/mods/eduardocalafell@fakemons/meta.json
+++ b/mods/eduardocalafell@fakemons/meta.json
@@ -3,7 +3,7 @@
   "title": "Fakémons",
   "author": "eduardocalafell",
   "summary": "Original fan-made Fakémons as real catchable species — full stats, moves, learnsets, dex entries and original art, spawning in themed habitats.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "categories": ["CONTENT", "GAMEPLAY"],
   "tags": ["fakemon", "pokemon", "species", "content"],
   "repo": "https://github.com/eduardocalafell/gen1recomp-fakemons",


### PR DESCRIPTION
Adds `mods/eduardocalafell@fakemons/`.

Original fan-made Fakémons added as real, catchable species (own stats, types, learnsets, TM/HM, dex entries and **original art**) that spawn in themed wild habitats. First roster: CINDRAKE (#152, Fire/Dragon; Pokémon Mansion, Lv 28-36). Single FAKEMONS on/off toggle. Data-driven for future additions.

- Repo: https://github.com/eduardocalafell/gen1recomp-fakemons
- Release v0.1.0 with the installable zip (files at the archive root).
- `node scripts/validate.mjs mods/eduardocalafell@fakemons` passes (0 warnings).
- meta.json id/api/profile/permissions/dependencies/conflicts match the mod's manifest.json.
- MIT; all art is original, nothing ROM-derived is distributed.