### PR TITLE
Point ShaneHudson@free_fly and @wild_skies at their new per-mod repos

### DIFF
--- a/mods/ShaneHudson@free_fly/meta.json
+++ b/mods/ShaneHudson@free_fly/meta.json
@@ -3,7 +3,7 @@
   "title": "Free Fly",
   "author": "ShaneHudson",
   "summary": "Ride a FLY user around the overworld and land wherever you like.",
-  "version": "1.0.0",
+  "version": "1.4.4",
   "categories": [
     "GAMEPLAY",
     "QOL"
@@ -14,8 +14,8 @@
     "mechanic",
     "quality-of-life"
   ],
-  "repo": "https://github.com/ShaneHudson/gen1recomp-mods",
-  "github": "ShaneHudson/gen1recomp-mods",
+  "repo": "https://github.com/shanehudson-gen1recomp-mods/free_fly",
+  "github": "shanehudson-gen1recomp-mods/free_fly",
   "automatic_version_check": true,
   "api": 2,
   "game_version": "0.0.0-dev || >=0.1.0 <2.0.0",

--- a/mods/ShaneHudson@wild_skies/description.md
+++ b/mods/ShaneHudson@wild_skies/description.md
@@ -9,6 +9,10 @@ and fly off when you get close. Reach a low one before it gets away and
 a normal wild battle starts with that species and level; high flyers
 never trigger battles from the ground.
 
+Under an open outdoor sky, 1 spawn in 1000 is a legendary bird
+(Articuno, Zapdos or Moltres, L48-52) instead of the map's usual pick.
+It flies alone and can be battled and caught like any other flyer.
+
 Options cover sky density and whether low birds can bump a walking
 player into a battle. Pairs well with Overworld Wild Encounters (its
 roamers handle the ground, these birds handle the air) and the Dramatic

--- a/mods/ShaneHudson@wild_skies/meta.json
+++ b/mods/ShaneHudson@wild_skies/meta.json
@@ -3,7 +3,7 @@
   "title": "Wild Skies",
   "author": "ShaneHudson",
   "summary": "Flying Pokémon from the encounter tables cross the overworld.",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "categories": [
     "GAMEPLAY",
     "ART",
@@ -15,8 +15,8 @@
     "flying",
     "encounters"
   ],
-  "repo": "https://github.com/ShaneHudson/gen1recomp-mods",
-  "github": "ShaneHudson/gen1recomp-mods",
+  "repo": "https://github.com/shanehudson-gen1recomp-mods/wild_skies",
+  "github": "shanehudson-gen1recomp-mods/wild_skies",
   "automatic_version_check": true,
   "api": 2,
   "game_version": "0.0.0-dev || >=0.1.0 <2.0.0",


### PR DESCRIPTION
My mods moved from the ShaneHudson/gen1recomp-mods monorepo to per-mod repos under the shanehudson-gen1recomp-mods org, where releases are tagged. The old repo/github fields meant the nightly version check never saw those releases, so both listings were stuck at 1.0.0.

- free_fly: repo/github now shanehudson-gen1recomp-mods/free_fly, recorded version 1.4.4 (current release)
- wild_skies: repo/github now shanehudson-gen1recomp-mods/wild_skies, recorded version 1.5.0, plus a description line for the new legendary bird sightings

`node scripts/validate.mjs` passes on both entries. automatic_version_check stays on, so future releases should be picked up nightly from the new repos.