### PR TITLE
Add ShaneHudson@double_battles 0.2.2

### DIFF
--- a/mods/ShaneHudson@double_battles/description.md
+++ b/mods/ShaneHudson@double_battles/description.md
@@ -1,0 +1,26 @@
+Wild and trainer battles against two Pokémon at once: 1v2, full 2v2,
+trainer doubles and two-trainer pairs, in the classic layout, the wide
+layout and Dramatic Shape's 3D battle modes.
+
+Turn it on in Mod Settings: WILD DOUBLES set to SOMETIMES (about 30% of
+wild encounters) or ALWAYS. A second foe from the map's own encounter
+table appears beside the first, with its own HP bar. Both foes pick
+moves every turn, turn order runs across all battlers using the
+engine's normal speed rules, and each defeated foe pays out experience.
+When the lead foe faints, the second steps up and the battle carries on
+as a normal 1v1, so catching and running work as usual from there.
+
+Picking a move with both foes up opens a target prompt: a menu names
+both Pokémon, a blinking frame marks your aim on the sprite, A locks it
+in, B goes back. Throwing a ball opens the same prompt; catching one
+foe ends the battle and the other flees.
+
+With wild_skies installed, a wild double first looks for a visible bird
+near you: the encounter holds a moment while it flies to your side, and
+the battle starts against that exact bird. With Dramatic Shape
+installed, both Pokémon on each side stand together on the 3D arena and
+the HUD follows whoever is acting.
+
+Still early (0.x): link play refuses modded formats, and some
+end-of-turn effects don't yet reach the second foe. The changelog in
+the repo tracks what works.

--- a/mods/ShaneHudson@double_battles/meta.json
+++ b/mods/ShaneHudson@double_battles/meta.json
@@ -1,0 +1,29 @@
+{
+  "id": "double_battles",
+  "title": "Double Battles",
+  "author": "ShaneHudson",
+  "summary": "Wild and trainer double battles: 1v2, 2v2 and trainer pairs, in classic, wide and 3D.",
+  "version": "0.2.2",
+  "categories": [
+    "GAMEPLAY"
+  ],
+  "tags": [
+    "battle",
+    "doubles",
+    "mechanic",
+    "wild",
+    "trainers"
+  ],
+  "repo": "https://github.com/shanehudson-gen1recomp-mods/double_battles",
+  "github": "shanehudson-gen1recomp-mods/double_battles",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": "0.0.0-dev || >=0.1.0 <2.0.0",
+  "profile": "content",
+  "affects_link": true,
+  "experimental": true,
+  "permissions": [
+    "engine_internals"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Wild and trainer double battles: 1v2, full 2v2, trainer doubles and two-trainer pairs, in the classic layout, the wide layout and Dramatic Shape's 3D battle modes.

Repo: https://github.com/shanehudson-gen1recomp-mods/double_battles (releases tagged there, current 0.2.2). Marked `experimental` since it's still 0.x, and `affects_link` to match the manifest (link play refuses modded formats). meta.json matches the manifest's id, api, permissions and game_version. `node scripts/validate.mjs` passes.