### PR TITLE
Add ShaneHudson@dev-hook-inspector 0.1.1

### DIFF
--- a/mods/ShaneHudson@dev-hook-inspector/description.md
+++ b/mods/ShaneHudson@dev-hook-inspector/description.md
@@ -1,0 +1,17 @@
+A developer tool for mod authors; regular players don't need it.
+
+Once installed, the START menu gains a HOOKS entry listing every loaded
+mod. Pick one to see its public surface: the exports other mods can
+call through `mod.find(id)`, and the events it broadcasts. Pick a hook
+to read its description. Every pick is also printed to the console,
+untruncated and copyable.
+
+No mod has to cooperate to show up. Exports are enumerated live off
+the loader, so the list reflects what is actually installed and
+running. Events are found in each mod's own source, and a watcher on
+the event bus catches names built at runtime. A hook's description is
+the comment written above its definition, when there is one.
+
+The model behind the screens is itself a public hook:
+`exports.inspect()` returns every loaded mod with its hooks, so other
+tools can build on the same data.

--- a/mods/ShaneHudson@dev-hook-inspector/meta.json
+++ b/mods/ShaneHudson@dev-hook-inspector/meta.json
@@ -1,0 +1,27 @@
+{
+  "id": "dev-hook-inspector",
+  "title": "Dev Hook Inspector",
+  "author": "ShaneHudson",
+  "summary": "Developer tool: a HOOKS entry on the START menu lists every installed mod's public exports and events.",
+  "version": "0.1.1",
+  "categories": [
+    "TOOL"
+  ],
+  "tags": [
+    "developer",
+    "exports",
+    "events",
+    "modding",
+    "debugging"
+  ],
+  "repo": "https://github.com/shanehudson-gen1recomp-mods/dev-hook-inspector",
+  "github": "shanehudson-gen1recomp-mods/dev-hook-inspector",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": "0.0.0-dev || >=0.1.0 <2.0.0",
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
A developer tool for mod authors, listed under TOOL: a HOOKS entry on the START menu lists every installed mod's public exports and events, enumerated live off the loader with no cooperation needed from the inspected mods. Regular players don't need it and the description says so.

Repo: https://github.com/shanehudson-gen1recomp-mods/dev-hook-inspector (releases tagged there, current 0.1.1). meta.json matches the manifest's id, api, permissions and game_version. `node scripts/validate.mjs` passes.