### PR TITLE
Add Pokemon Snag 0.12.0

### DIFF
--- a/mods/MisterMiracle@snag_quest/description.md
+++ b/mods/MisterMiracle@snag_quest/description.md
@@ -1,0 +1,19 @@
+Snag Quest adds a Team Rocket questline to gen1recomp. Jessie recruits
+you in Viridian City with a custom **Snag Ball** that steals Pokémon
+straight out of trainer battles — starting with a guaranteed shiny
+Meowth from a picnicker who isn't what she seems.
+
+Beyond the intro quest, a network of black-market "fences" scattered
+around Kanto will buy snagged Pokémon off you for more Snag Balls,
+paying more for high-level, hard-to-catch, or VIP-owned mons (your
+rival, gym leaders, the Elite Four).
+
+**Features**
+- Guaranteed shiny snag as the questline reward
+- Trainer-battle-only custom ball with permanent snag marking
+- Optional: battles continue after a snag instead of ending
+- Optional: Snag Balls purchasable in marts
+- Fences at Celadon Game Corner and Pewter City (Boulder Badge gated)
+
+Compatible with Quest System (required), kanto_ribbons, SHINY_POKEMON
+(optional), and voxel mode.

--- a/mods/MisterMiracle@snag_quest/meta.json
+++ b/mods/MisterMiracle@snag_quest/meta.json
@@ -1,0 +1,29 @@
+{
+  "id": "snag_quest",
+  "title": "Pokemon Snag",
+  "author": "Mister Miracle",
+  "version": "0.12.0",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT"
+  ],
+  "repo": "https://github.com/mistermiracle3036/Pokemon-Snag",
+  "summary": "Steal Pokemon from other trainers with the SNAG BALL, and fence what you steal for more balls.",
+  "tags": [
+    "theft",
+    "snag",
+    "trainer-battles",
+    "questline",
+    "team-rocket"
+  ],
+  "github": "mistermiracle3036/Pokemon-Snag",
+  "game_version": ">=0.1.38",
+  "dependencies": [
+    "quest_system"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/MisterMiracle@snag_quest/` — **Pokemon Snag** 0.12.0 by Mister Miracle.

- Source: https://github.com/mistermiracle3036/Pokemon-Snag
- Releases tracked from: `mistermiracle3036/Pokemon-Snag`
- Categories: GAMEPLAY, CONTENT
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>