### PR TITLE
Add Gen1 KR 0.3.2 with DRAMALESS_SHAPE dependency

### DIFF
--- a/mods/adrian@gen1_kr/meta.json
+++ b/mods/adrian@gen1_kr/meta.json
@@ -3,7 +3,7 @@
   "title": "Gen1 KR",
   "author": "adrian",
   "summary": "Drive KITT across Kanto.",
-  "version": "0.2.0",
+  "version": "3.0.2",
   "categories": [
     "GAMEPLAY",
     "AUDIO",
@@ -15,12 +15,13 @@
     "kitt"
   ],
   "github": "castdrian/gen1-kr",
+  "downloadURL": "https://github.com/castdrian/gen1-kr/releases/download/v3.0.2/gen1-kr-3.0.2.zip",
   "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
   "permissions": [
     "engine_internals"
   ],
   "dependencies": [
-    "DRAMATIC_SHAPE@>=1.6.0 <2.0.0"
+    "DRAMALESS_SHAPE@>=1.6.3 <2.0.0"
   ],
   "conflicts": [],
   "api": 2,

--- a/mods/adrian@gen1_kr/meta.json
+++ b/mods/adrian@gen1_kr/meta.json
@@ -3,7 +3,7 @@
   "title": "Gen1 KR",
   "author": "adrian",
   "summary": "Drive KITT across Kanto.",
-  "version": "3.0.2",
+  "version": "0.3.2",
   "categories": [
     "GAMEPLAY",
     "AUDIO",
@@ -15,7 +15,7 @@
     "kitt"
   ],
   "github": "castdrian/gen1-kr",
-  "downloadURL": "https://github.com/castdrian/gen1-kr/releases/download/v3.0.2/gen1-kr-3.0.2.zip",
+  "downloadURL": "https://github.com/castdrian/gen1-kr/releases/download/v0.3.2/gen1-kr-0.3.2.zip",
   "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
   "permissions": [
     "engine_internals"


### PR DESCRIPTION
declares DRAMALESS_SHAPE >=1.6.3 <2.0.0.

Release: https://github.com/castdrian/gen1-kr/releases/tag/v0.3.2

Validation: node scripts/validate.mjs mods/adrian@gen1_kr; node --test scripts/test.mjs