### PR TITLE
Add Recomp Cartographer 0.2.0

### DIFF
--- a/mods/Sedatb23@recomp_cartographer/description.md
+++ b/mods/Sedatb23@recomp_cartographer/description.md
@@ -1,0 +1,4 @@
+This mod allows dumping of the maps into tiled. 
+You can then make changes to the maps as you please and after a simply restart of the game, the map(s) that you have modified are loaded in!
+
+The export is saved at %APPDATA%/pokemon-love2d/recomp_cartographer_workspace

--- a/mods/Sedatb23@recomp_cartographer/meta.json
+++ b/mods/Sedatb23@recomp_cartographer/meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "recomp_cartographer",
+  "title": "Recomp Cartographer",
+  "author": "Sedatb23",
+  "version": "0.2.0",
+  "categories": [
+    "ART"
+  ],
+  "repo": "https://github.com/Sedatb23/recomp_cartographer",
+  "github": "Sedatb23/recomp_cartographer",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Sedatb23@recomp_cartographer/` — **Recomp Cartographer** 0.2.0 by Sedatb23.

- Source: https://github.com/Sedatb23/recomp_cartographer
- Releases tracked from: `Sedatb23/recomp_cartographer`
- Categories: ART
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>