### PR TITLE
Add Music2-HGSS 26.08.11

### DIFF
--- a/mods/DaroMelo@Music2_HGSS/description.md
+++ b/mods/DaroMelo@Music2_HGSS/description.md
@@ -1,0 +1,1 @@
+Music from HeartGold / SoulSilver

--- a/mods/DaroMelo@Music2_HGSS/meta.json
+++ b/mods/DaroMelo@Music2_HGSS/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "Music2_HGSS",
+  "title": "Music2-HGSS",
+  "author": "DaríoMelo",
+  "version": "26.08.11",
+  "categories": [
+    "CONTENT",
+    "AUDIO"
+  ],
+  "repo": "https://github.com/DarioMelo/Gen1Recomp-Music2-HGSS",
+  "tags": [
+    "audio",
+    "music"
+  ],
+  "github": "DarioMelo/Gen1Recomp-Music2-HGSS",
+  "game_version": ">=0.1.78",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/DaroMelo@Music2_HGSS/` — **Music2-HGSS** 26.08.11 by DaríoMelo.

- Source: https://github.com/DarioMelo/Gen1Recomp-Music2-HGSS
- Releases tracked from: `DarioMelo/Gen1Recomp-Music2-HGSS`
- Categories: CONTENT, AUDIO
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>