### PR TITLE
Add Dramatic Shape Voxel Mod 1.8.2

### DIFF
--- a/mods/scottcandy34@DRAMATIC_SHAPE/description.md
+++ b/mods/scottcandy34@DRAMATIC_SHAPE/description.md
@@ -1,0 +1,23 @@
+# Dramatic Shape Voxel Mod
+
+Last known release 1.8.2
+
+The overworld as a 3D diorama. Terrain is extruded into real geometry,
+occlusion comes from a depth buffer rather than a y-sort, characters stand as
+leaning sprite slabs, a shadow map throws real cast shadows across whatever
+they land on, and an optional tilt-shift pass turns the whole thing into a
+miniature.
+
+Battles are fought on the map itself, shot over the shoulder at the nearest
+clear ground with a slow parallax drift.
+
+Declares `affects_link: false`: link play is unaffected.
+
+## Install
+
+1. Download `DRAMATIC_SHAPE-1.8.2.zip` from the
+   [releases page](https://github.com/scottcandy34/DramaticShapeVoxelMod/releases).
+2. In the launcher: MODS → **Import mod .zip**.
+
+With `"github": "scottcandy34/DramaticShapeVoxelMod"` set, the launcher's **Update**
+and **Versions** buttons handle new releases from there.

--- a/mods/scottcandy34@DRAMATIC_SHAPE/meta.json
+++ b/mods/scottcandy34@DRAMATIC_SHAPE/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "DRAMATIC_SHAPE",
+  "title": "Dramatic Shape Voxel Mod",
+  "author": "scottcandy34",
+  "version": "1.8.2",
+  "categories": [
+    "ART",
+    "UI"
+  ],
+  "repo": "https://github.com/scottcandy34/DramaticShapeVoxelMod-latest",
+  "summary": "The overworld as a 3D voxel diorama: extruded terrain, cast shadows, tilt-shift, and battles fought on the map itself.",
+  "tags": [
+    "voxel",
+    "3d",
+    "graphics",
+    "diorama",
+    "fork"
+  ],
+  "github": "scottcandy34/DramaticShapeVoxelMod-latest",
+  "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",
+  "conflicts": [
+    "potato_voxel",
+    "BATTLE_ART_VOXEL_FORK",
+    "TERRARIUM"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/scottcandy34@DRAMATIC_SHAPE/` — **Dramatic Shape Voxel Mod** 1.8.2 by scottcandy34.

- Source: https://github.com/scottcandy34/DramaticShapeVoxelMod-latest
- Releases tracked from: `scottcandy34/DramaticShapeVoxelMod-latest`
- Categories: ART, UI
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>