### PR TITLE
Update PokéPC Followers for Gold support

### DIFF
--- a/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/description.md
+++ b/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/description.md
@@ -1,1 +1,5 @@
-An all-species overworld follower mod for Pokémon Red, Blue, and Yellow (Gen 1 Recomp). This mod allows every single Gen 1 Pokémon to walk behind you in full overworld color as your companion!
+PokéPC Followers lets any healthy party Pokémon walk behind you as a full-color overworld companion in Pokémon Red, Blue, Yellow, and Gold.
+
+Gold supports all 251 species natively. On Gen 1, the original 151 work out of the box and Johto species can be supplied by a compatible expansion such as Crystal 251. Followers use Pokédex-proportional sizing, can be selected from the Party Menu, disappear correctly while biking or surfing, and support the Dramatic Shape voxel renderer.
+
+This listing tracks the Gold-compatible fork maintained by MFRTechConsult. The original project and author attribution remain credited to Gamecorner_033 and Antigravity.

--- a/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/meta.json
+++ b/mods/Gamecorner_033@PokePCFollowers_VoxelMerge/meta.json
@@ -1,16 +1,28 @@
 {
   "id": "PokePCFollowers_VoxelMerge",
-  "title": "PokéPC Followers (W/Voxel Support)",
+  "title": "PokéPC Followers (Gold + Voxel Support)",
   "author": "Gamecorner_033",
-  "version": "0.5.1",
+  "summary": "Any healthy party Pokémon can follow you in Red, Blue, Yellow, or Gold, with all 251 species, proportional sizing, full-color art, and voxel support.",
+  "version": "0.8.0",
   "categories": [
     "GAMEPLAY",
     "CONTENT",
     "ART",
-    "LIBRARY"
+    "QOL"
   ],
-  "repo": "https://github.com/gamecorner-033/PokePCFollowers",
-  "github": "gamecorner-033/PokePCFollowers",
+  "tags": [
+    "followers",
+    "gold",
+    "gen 2",
+    "all species",
+    "voxel"
+  ],
+  "repo": "https://github.com/mfrtechconsult/PokePCFollowers",
+  "github": "mfrtechconsult/PokePCFollowers",
+  "automatic_version_check": true,
   "api": 2,
-  "profile": "content"
+  "profile": "content",
+  "permissions": [
+    "engine_internals"
+  ]
 }


### PR DESCRIPTION
**Mod:** PokéPC Followers (Gold + Voxel Support) 0.8.0 by Gamecorner_033, Gold-compatible fork maintained by MFRTechConsult

**Folder:** `mods/Gamecorner_033@PokePCFollowers_VoxelMerge/`

**Source:** https://github.com/mfrtechconsult/PokePCFollowers

## What changed

- Updates the existing listing from 0.5.1 to 0.8.0.
- Tracks the maintained Gold-compatible fork and its installable `v0.8.0` release.
- Refreshes the title, summary, categories, tags, description, and declared `engine_internals` permission.
- Keeps the original mod ID, folder, and Gamecorner_033 attribution instead of creating a duplicate entry.

The original repository currently has no installable GitHub Release. The maintained fork adds Pokémon Gold / Gen 2 support and publishes `mod.zip`, allowing the index and launcher's Update / Versions flow to resolve a working download. The description continues to credit Gamecorner_033 and Antigravity.

- [x] `modkit.py validate PokePCFollowers_VoxelMerge --strict` and `modkit.py lint PokePCFollowers_VoxelMerge` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/Gamecorner_033@PokePCFollowers_VoxelMerge/`

Index-side checks also pass: UTF-8, schema validation, duplicate detection, release links, and all 21 tests.
