### PR TITLE
Update Gen1MMO listing to 1.5.1

### DIFF
--- a/mods/tebwritescode@gen1mmo/description.md
+++ b/mods/tebwritescode@gen1mmo/description.md
@@ -1,12 +1,20 @@
-**Online play for Gen1Recomp — other trainers, live in your own save.**
+**An MMO for Gen1Recomp — everyone shares one world on a free public
+server, with nothing to host and no data collected.**
 
 Gen1MMO overlays multiplayer onto the single-player save you already have:
 the trainer other players meet is yours, badges, box and all, and you keep
 playing the game you were already playing. Other players appear in your
 overworld with floating nametags; chat rides a fading panel in the game's
 own menu style (native keyboard input on phones); press A on a player to
-open their **trainer card** — badges, money, and their party — with
-Whisper and Add friend right there.
+open their **trainer card** — badges, money, party, title and history —
+with Whisper and Add friend right there.
+
+**Make history:** 43 collectible history badges are earned by playing —
+gym badges and the Hall of Fame, catches by type and Pokedex milestones,
+fishing, evolutions, trades, boulders, long walks — and the ones you earn
+unlock **titles** you can wear on your card. **Emotes** (heart, wave,
+fist) drop into the world where you stand and fade behind you like
+breadcrumbs.
 
 **Character customisation (work in progress):** pick your body from
 sixteen of the game's own people sprites and recolor its regions — skin
@@ -22,8 +30,9 @@ copy only when it gets genuinely crowded.
 
 Privacy is the project's constitution: accounts are a name and password
 (recovery by one-time code — no email, no phone, no personal data), chat
-is filtered and never stored, transport is end-to-end encrypted against a
-pinned server identity, and the server retains no IPs and no play history.
+is filtered and never stored, whispers are between mutual friends only,
+transport is end-to-end encrypted against a pinned server identity, and
+the server retains no IPs and no play history.
 
 One official server runs 24/7 and is baked in: install, register in-game,
 play.

--- a/mods/tebwritescode@gen1mmo/meta.json
+++ b/mods/tebwritescode@gen1mmo/meta.json
@@ -2,7 +2,7 @@
   "id": "gen1mmo",
   "title": "Gen1MMO",
   "author": "tebwritescode",
-  "version": "1.3.0",
+  "version": "1.5.1",
   "categories": [
     "GAMEPLAY",
     "CONTENT",


### PR DESCRIPTION
Listing update for **Gen1MMO** (tebwritescode) — the entry has been in the index since #106 at 1.3.0, and the description has fallen behind two feature releases.

- Description now covers what 1.4/1.5 added: 43 collectible history badges earned from in-game events, titles worn on the trainer card, and emotes dropped into the world as fading breadcrumbs. Also notes whispers are mutual-friends only. Customisation stays marked **work in progress**.
- `version` field bumped 1.3.0 -> 1.5.1 to match the current release (`automatic_version_check` already tracks downloads nightly — this is just the declared metadata catching up alongside the description change).
- No change to id, api, profile, permissions, categories, repo or thumbnail.

- Source: https://github.com/tebwritescode/gen1mmo
- Release: https://github.com/tebwritescode/gen1mmo/releases/tag/v1.5.1 (`gen1mmo-1.5.1.zip`, files at archive root)
- `node scripts/validate.mjs mods/tebwritescode@gen1mmo`: OK, 0 warnings; duplicates check passes.