### PR TITLE
Add Modern Type Framework 1.0.0

### DIFF
--- a/mods/MaybeGreg@modern_type_framework/description.md
+++ b/mods/MaybeGreg@modern_type_framework/description.md
@@ -1,0 +1,1 @@
+Updates the type chart to modern chart. Does not edit Pokémon or moves.

--- a/mods/MaybeGreg@modern_type_framework/meta.json
+++ b/mods/MaybeGreg@modern_type_framework/meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "modern_type_framework",
+  "title": "Modern Type Framework",
+  "author": "MaybeGreg",
+  "version": "1.0.0",
+  "categories": [
+    "LIBRARY"
+  ],
+  "repo": "https://github.com/MaybeGreg/modern_type_framework",
+  "github": "MaybeGreg/modern_type_framework",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/MaybeGreg@modern_type_framework/` — **Modern Type Framework** 1.0.0 by MaybeGreg.

- Source: https://github.com/MaybeGreg/modern_type_framework
- Releases tracked from: `MaybeGreg/modern_type_framework`
- Categories: LIBRARY
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>