### PR TITLE
Sync MadeinTaly mods: two new, four updated for Gold

### DIFF
--- a/mods/MadeinTaly@childhood_myths_are_real/description.md
+++ b/mods/MadeinTaly@childhood_myths_are_real/description.md
@@ -1,0 +1,5 @@
+The playground rumours of 1998, made true.
+
+Every Gen 1 player heard them: the things you could supposedly do if you knew the trick. This mod turns those schoolyard legends into real, opt-in behaviour, each one behind its own switch so you choose which myths your game believes.
+
+Everything is off by default and separately switchable, so nothing changes until you ask for it.

--- a/mods/MadeinTaly@childhood_myths_are_real/meta.json
+++ b/mods/MadeinTaly@childhood_myths_are_real/meta.json
@@ -1,0 +1,27 @@
+{
+  "id": "childhood_myths_are_real",
+  "title": "Childhood Myths Are Real",
+  "author": "MadeinTaly",
+  "version": "0.2.0",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT"
+  ],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-childhood-myths-are-real",
+  "github": "MadeinTaly/gen1recomp-childhood-myths-are-real",
+  "summary": "The playground rumours of 1998, made true: the schoolyard legends every Gen 1 player swore were real, as opt-in switches.",
+  "tags": [
+    "myths",
+    "legends",
+    "gameplay",
+    "secrets"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}

--- a/mods/MadeinTaly@gen3_box/description.md
+++ b/mods/MadeinTaly@gen3_box/description.md
@@ -35,3 +35,5 @@ passes 6, and if you are carrying a Pokemon while both are full the screen
 refuses to close rather than dropping it out of the save.
 
 Lua source only: no ROM, no ROM-derived data, no game assets.
+
+**On Gold.** Runs on Pokemon Gold as well as Red, Blue and Yellow: fourteen boxes of twenty instead of twelve, Gold's own summary screen, its split Special in a withdrawn Pokemon's stat block, and its MAIL rules honoured (a Pokemon holding mail cannot be boxed, exactly as the vanilla PC refuses it). GRID BIG is Gen 1 only -- Gold's boot scales a single Game Boy canvas and never asks a screen how big it would like to be.

--- a/mods/MadeinTaly@gen3_box/meta.json
+++ b/mods/MadeinTaly@gen3_box/meta.json
@@ -2,13 +2,26 @@
   "id": "gen3_box",
   "title": "Gen 3 Box",
   "author": "MadeinTaly",
-  "version": "1.5.2",
-  "categories": ["UI", "QOL"],
+  "version": "1.8.0",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-boxes",
   "github": "MadeinTaly/gen1recomp-gen3-boxes",
-  "summary": "A Gen 3-style storage screen: a 5x4 grid, a cursor that picks a Pokemon up and puts it down, and one button between box and party.",
-  "tags": ["boxes", "storage", "pc", "qol", "ui"],
-  "permissions": ["engine_internals"],
+  "summary": "A Gen 3-style storage screen: a 5x4 grid, a cursor that picks a Pokemon up and puts it down, and one button between box and party. Runs on Gold too.",
+  "tags": [
+    "boxes",
+    "storage",
+    "pc",
+    "qol",
+    "ui",
+    "gold",
+    "gen-2"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
   "api": 2,
   "profile": "content",
   "game_version": ">=0.0.0-0 <2.0.0",

--- a/mods/MadeinTaly@gen3_dex/description.md
+++ b/mods/MadeinTaly@gen3_dex/description.md
@@ -30,3 +30,5 @@ surface buys room and colour, never detail. It reads the save's dex and
 writes nothing.
 
 Lua source only: no ROM, no ROM-derived data and no game assets.
+
+**On Gold.** The dex covers Johto rather than stopping at Mew, the caught half is read where Gold actually keeps it, and DATA and AREA open Gold's own dex entry -- its AREA view is the nest map, so the map is one button further in. GRID BIG is read as CLASSIC there, for the same reason it is in Gen 3 Box.

--- a/mods/MadeinTaly@gen3_dex/description.md
+++ b/mods/MadeinTaly@gen3_dex/description.md
@@ -31,4 +31,4 @@ writes nothing.
 
 Lua source only: no ROM, no ROM-derived data and no game assets.
 
-**On Gold.** The dex covers Johto rather than stopping at Mew, the caught half is read where Gold actually keeps it, and DATA and AREA open Gold's own dex entry -- its AREA view is the nest map, so the map is one button further in. GRID BIG is read as CLASSIC there, for the same reason it is in Gen 3 Box.
+**On Gold.** The dex covers Johto rather than stopping at Mew, the caught half is read where Gold actually keeps it, and DATA and AREA open Gold's own dex entry. GRID BIG works there too, through the widescreen contract Gold's own screens use -- only the per-species palette zones stay Gen 1, because Gold colours itself.

--- a/mods/MadeinTaly@gen3_dex/meta.json
+++ b/mods/MadeinTaly@gen3_dex/meta.json
@@ -2,14 +2,14 @@
   "id": "gen3_dex",
   "title": "Gen 3 Dex",
   "author": "MadeinTaly",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "categories": [
     "UI",
     "ART"
   ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-dex",
   "github": "MadeinTaly/gen1recomp-gen3-dex",
-  "summary": "The Pokedex as a grid of pictures instead of a list of names, with owned species in their own colours. Covers Johto on Gold.",
+  "summary": "The Pokedex as a grid of pictures instead of a list of names, with owned species in their own colours. Covers Johto on Gold, where the big grid works too.",
   "tags": [
     "pokedex",
     "dex",

--- a/mods/MadeinTaly@gen3_dex/meta.json
+++ b/mods/MadeinTaly@gen3_dex/meta.json
@@ -2,13 +2,25 @@
   "id": "gen3_dex",
   "title": "Gen 3 Dex",
   "author": "MadeinTaly",
-  "version": "0.1.0",
-  "categories": ["UI", "ART"],
+  "version": "0.4.0",
+  "categories": [
+    "UI",
+    "ART"
+  ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-gen3-dex",
   "github": "MadeinTaly/gen1recomp-gen3-dex",
-  "summary": "The Pokedex as a grid of pictures, each owned species in its own colours, with ALL/OWNED/MISSING filters.",
-  "tags": ["pokedex", "ui", "grid", "cosmetic", "qol"],
-  "permissions": ["engine_internals"],
+  "summary": "The Pokedex as a grid of pictures instead of a list of names, with owned species in their own colours. Covers Johto on Gold.",
+  "tags": [
+    "pokedex",
+    "dex",
+    "ui",
+    "qol",
+    "gold",
+    "gen-2"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
   "api": 2,
   "profile": "content",
   "game_version": ">=0.0.0-0 <2.0.0",

--- a/mods/MadeinTaly@groovy_palette/description.md
+++ b/mods/MadeinTaly@groovy_palette/description.md
@@ -33,3 +33,5 @@ never the save.
 Lua source and original artwork only: no ROM, no ROM-derived data and no
 game assets. The border sheet is generated from rules in the repository's
 own `tools/make_frames.py`.
+
+**On Gold.** The frames work on Pokemon Gold: it draws its text boxes through the same Font.drawBox this mod rewrites the border codes for, and Gold's own FRAME option picks a frame page rather than the border glyphs, so the two do not fight. The palettes stay Gen 1 -- Gold is a CGB game whose colour comes from its own palettes, and its OPTION menu has no palette row at all.

--- a/mods/MadeinTaly@groovy_palette/description.md
+++ b/mods/MadeinTaly@groovy_palette/description.md
@@ -34,4 +34,4 @@ Lua source and original artwork only: no ROM, no ROM-derived data and no
 game assets. The border sheet is generated from rules in the repository's
 own `tools/make_frames.py`.
 
-**On Gold.** The frames work on Pokemon Gold: it draws its text boxes through the same Font.drawBox this mod rewrites the border codes for, and Gold's own FRAME option picks a frame page rather than the border glyphs, so the two do not fight. The palettes stay Gen 1 -- Gold is a CGB game whose colour comes from its own palettes, and its OPTION menu has no palette row at all.
+**On Gold.** Both halves work. The frames ride the same Font.drawBox Gold draws its boxes with, and the palettes reach Gold's own COLOR row through GbcPalette, the choke point every colour in the Gen 2 port arrives through. The boot cinema and title screen keep the cart's grey art, which is the same boundary Gold's own DMG mode sits behind.

--- a/mods/MadeinTaly@groovy_palette/meta.json
+++ b/mods/MadeinTaly@groovy_palette/meta.json
@@ -2,20 +2,22 @@
   "id": "groovy_palette",
   "title": "Groovy Palette & Frames",
   "author": "MadeinTaly",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "categories": [
     "ART",
     "UI"
   ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-groovy-palette-frames",
   "github": "MadeinTaly/gen1recomp-groovy-palette-frames",
-  "summary": "Thirty more COLORS palettes and eight text-box borders, previewed on the running game from the COLORS row itself.",
+  "summary": "Thirty extra colour palettes and nine text-box frames for the OPTIONS menu, with a live preview. The frames work on Gold too.",
   "tags": [
     "palette",
     "colours",
     "borders",
     "cosmetic",
-    "retro"
+    "retro",
+    "gold",
+    "gen-2"
   ],
   "permissions": [
     "engine_internals"

--- a/mods/MadeinTaly@groovy_palette/meta.json
+++ b/mods/MadeinTaly@groovy_palette/meta.json
@@ -2,14 +2,14 @@
   "id": "groovy_palette",
   "title": "Groovy Palette & Frames",
   "author": "MadeinTaly",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "categories": [
     "ART",
     "UI"
   ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-groovy-palette-frames",
   "github": "MadeinTaly/gen1recomp-groovy-palette-frames",
-  "summary": "Thirty extra colour palettes and nine text-box frames for the OPTIONS menu, with a live preview. The frames work on Gold too.",
+  "summary": "Thirty extra colour palettes and nine text-box frames, with a live preview. Both halves work on Gold.",
   "tags": [
     "palette",
     "colours",

--- a/mods/MadeinTaly@modern_johto/description.md
+++ b/mods/MadeinTaly@modern_johto/description.md
@@ -1,0 +1,7 @@
+Modern Johto brings the Gen 4 physical/special split to Pokemon Gold: a move's category is decided per move instead of per type.
+
+It matters more here than on Red. Gen 1 has a single Special stat, so moving a move between the two columns lands on the same number twice. Gold already splits Special into Special Attack and Special Defense, so a per-move category is the whole Gen 4 change. The Dark moves are the case in point: Dark is a special type whose moves are nearly all physical from Gen 4 on, which is why Umbreon and Tyranitar spend the generation attacking off the wrong column.
+
+SPLIT is off by default, because it changes the balance rather than fixing a bug.
+
+What it does not do: Counter and Mirror Coat still answer by the type rule, because whether a hit counted as physical or special for them is decided after the damage hook returns. This mod is Gen 2 only -- Modern Kanto is the Gen 1 counterpart, and five of that mod's six features have nothing to fix on Gold.

--- a/mods/MadeinTaly@modern_johto/meta.json
+++ b/mods/MadeinTaly@modern_johto/meta.json
@@ -2,14 +2,14 @@
   "id": "modern_johto",
   "title": "Modern Johto",
   "author": "MadeinTaly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "categories": [
     "GAMEPLAY",
     "BALANCE"
   ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-modern-johto",
   "github": "MadeinTaly/gen1recomp-modern-johto",
-  "summary": "The Gen 4 physical/special split for Pokemon Gold, decided per move instead of per type -- so Crunch comes off Attack and Shadow Ball off Special Attack.",
+  "summary": "The Gen 4 physical/special split for Pokemon Gold, decided per move instead of per type, plus an AI that reads type effectiveness where Gold left trainers type-blind.",
   "tags": [
     "split",
     "physical-special",

--- a/mods/MadeinTaly@modern_johto/meta.json
+++ b/mods/MadeinTaly@modern_johto/meta.json
@@ -1,0 +1,28 @@
+{
+  "id": "modern_johto",
+  "title": "Modern Johto",
+  "author": "MadeinTaly",
+  "version": "0.1.0",
+  "categories": [
+    "GAMEPLAY",
+    "BALANCE"
+  ],
+  "repo": "https://github.com/MadeinTaly/gen1recomp-modern-johto",
+  "github": "MadeinTaly/gen1recomp-modern-johto",
+  "summary": "The Gen 4 physical/special split for Pokemon Gold, decided per move instead of per type -- so Crunch comes off Attack and Shadow Ball off Special Attack.",
+  "tags": [
+    "split",
+    "physical-special",
+    "battle",
+    "gold",
+    "gen-2"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "license": "MIT",
+  "automatic_version_check": true
+}

--- a/mods/MadeinTaly@modern_kanto/meta.json
+++ b/mods/MadeinTaly@modern_kanto/meta.json
@@ -2,13 +2,24 @@
   "id": "modern_kanto",
   "title": "Modern Kanto",
   "author": "MadeinTaly",
-  "version": "0.2.0",
-  "categories": ["GAMEPLAY", "BALANCE", "UI"],
+  "version": "0.3.0",
+  "categories": [
+    "GAMEPLAY",
+    "BALANCE",
+    "UI"
+  ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-modern-kanto",
   "github": "MadeinTaly/gen1recomp-modern-kanto",
   "summary": "Four fixes Gen 1 never got: the move split, the corrected type rows, an AI that multiplies, and an encounter atlas.",
-  "tags": ["mechanic", "balance", "ui", "quality-of-life"],
-  "permissions": ["engine_internals"],
+  "tags": [
+    "mechanic",
+    "balance",
+    "ui",
+    "quality-of-life"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
   "api": 2,
   "profile": "overhaul",
   "game_version": ">=0.0.0-0 <2.0.0",

--- a/mods/MadeinTaly@running_shoes/description.md
+++ b/mods/MadeinTaly@running_shoes/description.md
@@ -42,3 +42,5 @@ quickly. It rides the engine's own `movement.speed` hook — whose comment
 names running shoes as the reason it exists — calls the next handler first
 and multiplies its answer, so a mod that slows you in a swamp keeps its say.
 It declares no permissions at all.
+
+**On Gold.** RUN SPEED, BOOST BIKE, BOOST SURF and SAFE GRASS all work: Gold raises the same movement.speed hook with the same keys, and it rebuilds the step duration every step, so a scripted cutscene can never inherit a running step the way it can on Gen 1. CUT GRASS and RUN FX are Gen 1 only and switch themselves off on Gold -- the cut needs a table with no Gen 2 home, and the trail is measured from the Gen 1 world canvas.

--- a/mods/MadeinTaly@running_shoes/description.md
+++ b/mods/MadeinTaly@running_shoes/description.md
@@ -43,4 +43,4 @@ names running shoes as the reason it exists — calls the next handler first
 and multiplies its answer, so a mod that slows you in a swamp keeps its say.
 It declares no permissions at all.
 
-**On Gold.** RUN SPEED, BOOST BIKE, BOOST SURF and SAFE GRASS all work: Gold raises the same movement.speed hook with the same keys, and it rebuilds the step duration every step, so a scripted cutscene can never inherit a running step the way it can on Gen 1. CUT GRASS and RUN FX are Gen 1 only and switch themselves off on Gold -- the cut needs a table with no Gen 2 home, and the trail is measured from the Gen 1 world canvas.
+**On Gold.** Everything works: the speed, the bike and surf boosts, SAFE GRASS, the trail, and CUT GRASS -- Gold cuts grass through its own FieldMoves.CUT_BLOCKS, and the trail only ever looked absent because the overworld test was asking a Gen 1 question. The engine's own dust puff has no Gen 2 equivalent, so there the trail is the mod's own particles.

--- a/mods/MadeinTaly@running_shoes/meta.json
+++ b/mods/MadeinTaly@running_shoes/meta.json
@@ -2,12 +2,21 @@
   "id": "running_shoes",
   "title": "Running Shoes",
   "author": "MadeinTaly",
-  "version": "1.1.0",
-  "categories": ["QOL", "GAMEPLAY"],
+  "version": "1.5.0",
+  "categories": [
+    "QOL",
+    "GAMEPLAY"
+  ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-running-shoes",
   "github": "MadeinTaly/gen1recomp-running-shoes",
-  "summary": "Hold B to walk faster, at a speed you pick. Gen 3 gave you these in five minutes; Gen 1 made you earn a bicycle.",
-  "tags": ["quality-of-life", "movement", "running", "beginner"],
+  "summary": "Hold B to walk faster, at a speed you pick. The speed, the bike and surf boosts and SAFE GRASS all work on Gold.",
+  "tags": [
+    "running",
+    "speed",
+    "qol",
+    "gold",
+    "gen-2"
+  ],
   "permissions": [],
   "api": 2,
   "profile": "content",

--- a/mods/MadeinTaly@running_shoes/meta.json
+++ b/mods/MadeinTaly@running_shoes/meta.json
@@ -2,14 +2,14 @@
   "id": "running_shoes",
   "title": "Running Shoes",
   "author": "MadeinTaly",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "categories": [
     "QOL",
     "GAMEPLAY"
   ],
   "repo": "https://github.com/MadeinTaly/gen1recomp-running-shoes",
   "github": "MadeinTaly/gen1recomp-running-shoes",
-  "summary": "Hold B to walk faster, at a speed you pick. The speed, the bike and surf boosts and SAFE GRASS all work on Gold.",
+  "summary": "Hold B to walk faster, at a speed you pick, with an optional trail and grass that really gets cut. Everything works on Gold.",
   "tags": [
     "running",
     "speed",


### PR DESCRIPTION
Four of these now run on Pokémon Gold, so this brings the listings in line with what the repos actually ship.

**New**

- **Modern Johto** 0.1.0 — the Gen 4 physical/special split for Gold, decided per move instead of per type. Gen 2 only: it is the counterpart of Modern Kanto, whose other five features have nothing to fix on Gold (Gold already has the corrected chart, the fixed quirks and no badge stat boost).
- **Childhood Myths Are Real** 0.2.0 — the playground rumours of 1998 as opt-in switches. Gen 1.

**Updated**

- **Gen 3 Box** 1.5.2 → **1.8.0** — now runs on Gold: fourteen boxes instead of twelve, Gold's own summary screen and stat block, and its MAIL rules honoured.
- **Gen 3 Dex** 0.1.0 → **0.4.0** — now runs on Gold: the dex covers Johto instead of stopping at Mew, and DATA/AREA route to Gold's own dex entry.
- **Running Shoes** 1.1.0 → **1.5.0** — now runs on Gold: the speed, the bike and surf boosts and SAFE GRASS all cross over. CUT GRASS and RUN FX stay Gen 1 and switch themselves off there.
- **Modern Kanto** 0.2.0 → **0.3.0** — unchanged in scope, still Gen 1.

Gold support is stated in each `summary`, `tags` and `description.md`, since the schema has no field for it.

**Not touched:** Groovy Palette & Frames. Its listing says 0.5.0 while its newest release is v0.4.1 — the manifest is a release ahead of the tag, so I left the entry alone rather than move it backwards. I will open a separate PR once that release is cut.

Versions are the published release tags, not the manifest values. All of these ship Lua source only — no ROM, no ROM-derived data, no game assets — and every release comes out of CI as `<id>-<version>.zip`. `node scripts/validate.mjs` passes: `OK — 95 entries checked`, with no warnings on any of these entries.