### PR TITLE
Add Silph Scope Network 0.12.1

### DIFF
--- a/mods/Nezara@silphscope_network/description.md
+++ b/mods/Nezara@silphscope_network/description.md
@@ -1,0 +1,7 @@
+Silph Scope Network is a semi-online multiplayer mod that allows you to send a copy of your player, and your current pokemon team, to other players worlds. 
+
+This is a Dark Sous Style Invasion mechanic. 
+
+Other plays can run into your character and engage in a pokemon battle. likewise while you explore the world, you may run into other player trainers put in your path to stop you.
+
+Play with the whole world or in a private pool with your friends, create challenges or act as obstacles to others, the choice is yours.  

--- a/mods/Nezara@silphscope_network/meta.json
+++ b/mods/Nezara@silphscope_network/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "silphscope_network",
+  "title": "Silph Scope Network",
+  "author": "Nezara",
+  "version": "0.12.1",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT",
+    "OTHER"
+  ],
+  "repo": "https://github.com/Nezara/silph-scope-network",
+  "summary": "online invasion mechanic with players across the world.",
+  "tags": [
+    "multiplayer",
+    "pvp",
+    "online",
+    "versus",
+    "dark souls",
+    "friends",
+    "streaming"
+  ],
+  "github": "Nezara/silph-scope-network",
+  "downloadURL": "https://github.com/Nezara/silph-scope-network/releases/download/v0.12.1/silphscope_network-0.12.1.zip",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Nezara@silphscope_network/` — **Silph Scope Network** 0.12.1 by Nezara.

- Source: https://github.com/Nezara/silph-scope-network
- Releases tracked from: `Nezara/silph-scope-network`
- Categories: GAMEPLAY, CONTENT, OTHER
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>