### PR TITLE
Add Crystal Player Mod 0.7.6

### DIFF
--- a/mods/Dgray66@crystal/description.md
+++ b/mods/Dgray66@crystal/description.md
@@ -1,0 +1,3 @@
+The definitive Kris mod.
+
+Replaces the MC's Sprite with Kris from Pokemon Crystal. Regender's the male text to female or neutral. Add's community sprites to battles and trainer cards.

--- a/mods/Dgray66@crystal/meta.json
+++ b/mods/Dgray66@crystal/meta.json
@@ -2,7 +2,7 @@
   "id": "crystal",
   "title": "Crystal Player Mod",
   "author": "Dgray66",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "categories": [
     "CONTENT",
     "ART"

--- a/mods/Dgray66@crystal/meta.json
+++ b/mods/Dgray66@crystal/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "crystal",
+  "title": "Crystal Player Mod",
+  "author": "Dgray66",
+  "version": "0.7.5",
+  "categories": [
+    "CONTENT",
+    "ART"
+  ],
+  "repo": "https://github.com/dburton95/crystal",
+  "tags": [
+    "sprites",
+    "text",
+    "girl",
+    "crystal",
+    "teamkris"
+  ],
+  "github": "dburton95/crystal",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Dgray66@crystal/` — **Crystal Player Mod** 0.7.5 by Dgray66.

- Source: https://github.com/dburton95/crystal
- Releases tracked from: `dburton95/crystal`
- Categories: CONTENT, ART
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>