### PR TITLE
Add Trainer Talk 0.2.6

### DIFF
--- a/mods/Elvie@event_soundbytes/description.md
+++ b/mods/Elvie@event_soundbytes/description.md
@@ -1,0 +1,53 @@
+# Event Soundbytes
+
+A [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp) mod that plays a voice line when the player starts a New Game or Continues an existing save, with the music briefly ducking underneath each line.
+
+Built as a companion to the [Crystal](https://github.com/dburton95/crystal) player mod — the voice lines are Kris's lines from *Pokémon Masters EX*, so if you're already using Crystal to look the part, Event Soundbytes gives her a voice to match. It works fine on its own too, without Crystal installed.
+
+## Features
+
+- A single fixed voice line plays on **New Game**
+- One of three random voice lines plays on **Continue**, so reloading a save doesn't feel identical every time
+- Background music ducks briefly while a line plays, so it isn't buried
+- Works on Gen 1 (Red/Blue/Yellow) and Gen 2 (Gold)
+
+## Installation
+
+1. Download the latest release `.zip` from the [Releases](../../releases) page.
+2. In-game: **MODS → Import mod .zip**, or extract manually into your Gen1Recomp `mods/` folder:
+   - Windows: `%APPDATA%\love\pokemon-love2d\mods\`
+   - macOS: `~/Library/Application Support/LOVE/pokemon-love2d/mods/`
+   - Linux: `~/.local/share/love/pokemon-love2d/mods/`
+3. Restart the game.
+4. Open the **MODS** panel and confirm **Event Soundbytes** shows as `ENABLED`.
+
+## How it works
+
+Gen1Recomp doesn't expose a hook that fires directly on a title-screen button press, so this mod listens for:
+
+- `intro.oak_speech.finished` — fires once the player finishes the New Game naming/intro sequence
+- `save.loaded` — fires after an existing save is read and validated (Continue)
+
+Music ducking hooks `music.volume` and briefly scales it down for a couple of seconds after either line starts.
+
+## Assets
+
+Sound files live in `assets/` and aren't tracked as placeholders in this repo structure — replace them with your own if you fork this:
+
+- `assets/new_game.ogg` — plays on New Game
+- `assets/continue1.ogg`, `assets/continue2.ogg`, `assets/continue3.ogg` — random pool for Continue
+
+## Known limitations
+
+- Voice lines are shared across all party/player customization — no per-save or per-character variant selection yet.
+- No in-game toggle yet to disable the sounds without removing the mod.
+- Jessie character option only has a new game voice line and it's Kris's. For now it's a place holder and all other events are silent with Jessie selected.
+
+## Credits
+
+- Voice lines: Kris, *Pokémon Masters EX* (DeNA / The Pokémon Company)
+- Built to pair with [Crystal](https://github.com/dburton95/crystal) by dburton95
+
+## Contributing
+
+Forks and collaboration are welcome — whether that's swapping in your own voice lines, hooking additional events, or general improvements. Feel free to open a PR or an issue.

--- a/mods/Elvie@event_soundbytes/description.md
+++ b/mods/Elvie@event_soundbytes/description.md
@@ -1,4 +1,4 @@
-# Event Soundbytes
+# Trainer Talk
 
 A [Gen1Recomp](https://github.com/bryanthaboi/gen1recomp) mod that plays a voice line when the player starts a New Game or Continues an existing save, with the music briefly ducking underneath each line.
 

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -16,7 +16,7 @@
     "character"
   ],
   "github": "ElvieBlooms/Event_Soundbytes",
-  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.0/Event_Soundbytes_0.2.4.zip",
+  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.4/Event_Soundbytes_0.2.4.zip",
   "api": 2,
   "profile": "content"
 }

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -2,7 +2,7 @@
   "id": "event_soundbytes",
   "title": "Event Soundbytes",
   "author": "Elvie",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "categories": [
     "CONTENT",
     "AUDIO",

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -1,22 +1,22 @@
 {
-  "id": "event_soundbytes",
-  "title": "Event Soundbytes",
+  "id": "trainer_talk",
+  "title": "Trainer Talk",
   "author": "Elvie",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "categories": [
     "CONTENT",
     "AUDIO",
     "OTHER"
   ],
-  "repo": "https://github.com/ElvieBlooms/Event_Soundbytes",
+  "repo": "https://github.com/ElvieBlooms/trainer_talk",
   "summary": "Plays a voice line when the player triggers an event such as a New Game or Continues an existing save, with the music briefly ducking underneath each line.",
   "tags": [
     "voice lines",
     "soundbytes",
     "character"
   ],
-  "github": "ElvieBlooms/Event_Soundbytes",
-  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.4/Event_Soundbytes_0.2.4.zip",
+  "github": "ElvieBlooms/trainer_talk",
+  "downloadURL": "https://github.com/ElvieBlooms/trainer_talk/releases/download/v0.2.5/trainer_talk-0.2.5.zip",
   "api": 2,
   "profile": "content"
 }

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -1,0 +1,22 @@
+{
+  "id": "event_soundbytes",
+  "title": "Event Soundbytes",
+  "author": "Elvie",
+  "version": "0.2.0",
+  "categories": [
+    "CONTENT",
+    "AUDIO",
+    "OTHER"
+  ],
+  "repo": "https://github.com/ElvieBlooms/Event_Soundbytes",
+  "summary": "Plays a voice line when the player triggers an event such as a New Game or Continues an existing save, with the music briefly ducking underneath each line.",
+  "tags": [
+    "voice lines",
+    "soundbytes",
+    "character"
+  ],
+  "github": "ElvieBlooms/Event_Soundbytes",
+  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.0/Event_Soundbytes_0.2.0.zip",
+  "api": 2,
+  "profile": "content"
+}

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -2,7 +2,7 @@
   "id": "trainer_talk",
   "title": "Trainer Talk",
   "author": "Elvie",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "categories": [
     "CONTENT",
     "AUDIO",
@@ -16,7 +16,7 @@
     "character"
   ],
   "github": "ElvieBlooms/trainer_talk",
-  "downloadURL": "https://github.com/ElvieBlooms/trainer_talk/releases/download/v0.2.5/trainer_talk-0.2.5.zip",
+  "downloadURL": "https://github.com/ElvieBlooms/trainer_talk/releases/download/v0.2.6/trainer_talk-0.2.6.zip",
   "api": 2,
   "profile": "content"
 }

--- a/mods/Elvie@event_soundbytes/meta.json
+++ b/mods/Elvie@event_soundbytes/meta.json
@@ -16,7 +16,7 @@
     "character"
   ],
   "github": "ElvieBlooms/Event_Soundbytes",
-  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.0/Event_Soundbytes_0.2.0.zip",
+  "downloadURL": "https://github.com/ElvieBlooms/Event_Soundbytes/releases/download/v0.2.0/Event_Soundbytes_0.2.4.zip",
   "api": 2,
   "profile": "content"
 }


### PR DESCRIPTION
Adds `mods/Elvie@event_soundbytes/` — **Event Soundbytes** 0.2.0 by Elvie.

- Source: https://github.com/ElvieBlooms/Event_Soundbytes
- Releases tracked from: `ElvieBlooms/Event_Soundbytes`
- Categories: CONTENT, AUDIO, OTHER
- Profile: `content`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>