### PR TITLE
Add Gym Leader Shuffle

### DIFF
--- a/mods/inmento@gym_leader_shuffle/description.md
+++ b/mods/inmento@gym_leader_shuffle/description.md
@@ -1,65 +1,23 @@
 # Gym Leader Shuffle
 
-
-
 Gym Leader Shuffle creates a persistent per-save derangement of the eight Kanto Gym Leaders. The visiting leader supplies the overworld sprite, portrait, introductory dialogue, and a team scaled to the physical gym. The gym itself retains its original badge, TM, rewards, defeat wording, progression flag, and trainer-deactivation behavior.
-
-
 
 ## What it changes
 
+Each new mapping assigns every Kanto Gym Leader to a different gym, with no leader remaining in their original gym. The visiting leader’s team is adjusted to the destination gym’s level curve, including evolution or de-evolution where necessary.
 
+When enabled, SHUFFLE GYM TRAINERS applies the visiting leader’s non-leader gym-trainer roster to that gym while preserving its intended level curve. RANDOMIZE MOVE SETS, PREFER GYM-TYPE MOVES, ALLOW NATIVE STAB MOVES, and ENSURE A DAMAGING MOVE control the optional move-set generator.
 
-- Each new mapping assigns every Kanto Gym Leader to a different gym, with no leader remaining in their original gym.
-- 
-- The leader’s team is adjusted to the destination gym’s level curve, including evolution or de-evolution where necessary.
-- 
-- **SHUFFLE GYM TRAINERS** optionally applies the visiting leader’s non-leader gym-trainer roster to that gym while preserving its intended level curve.
-- 
-- **RANDOMIZE MOVE SETS**, **PREFER GYM-TYPE MOVES**, **ALLOW NATIVE STAB MOVES**, and **ENSURE A DAMAGING MOVE** control the optional move-set generator.
-- 
-- **OPEN SPOILER LOG** displays the eight saved leader-to-badge assignments.
-- 
-- **GYM TELEPORT (TEST)** and **RETURN TO LAST POINT (TEST)** are one-shot testing utilities for navigating the next eligible gym and returning to the original location.
-- 
-
-
-Giovanni’s Rocket Hideout and Silph Co. appearances are not shuffled; only his Viridian Gym appearance participates.
-
-
+OPEN SPOILER LOG displays the eight saved leader-to-badge assignments. GYM TELEPORT (TEST) and RETURN TO LAST POINT (TEST) are one-shot testing utilities for navigating the next eligible gym and returning to the original location. Giovanni’s Rocket Hideout and Silph Co. appearances are not shuffled; only his Viridian Gym appearance participates.
 
 ## Install
 
-
-
-1. Download `gym_leader_shuffle-0.0.1.zip` from the source repository’s Releases page.
-2. 
-2. In Gen 1 Recomp, open **MODS** and select **Import mod .zip**.
-3. 
-3. Enable the mod and start a New Game, or load a save before entering a Kanto gym to create its persistent mapping.
-4. 
-
+Download `gym_leader_shuffle-0.0.1.zip` from the source repository’s Releases page. In Gen 1 Recomp, open MODS and select Import mod .zip. Enable the mod and start a New Game, or load a save before entering a Kanto gym to create its persistent mapping.
 
 ## Compatibility
 
-
-
 Gym Leader Shuffle uses Mod API 2 with the `content` profile and does not affect link play. It has no declared dependencies or conflicts. It contains no ROM-derived content.
-
-
 
 ## License
 
-
-
 Gym Leader Shuffle is distributed under the MIT License. See the source repository for the full license text.
-
-
-
-
-
-
-
-
-
-

--- a/mods/inmento@gym_leader_shuffle/description.md
+++ b/mods/inmento@gym_leader_shuffle/description.md
@@ -1,0 +1,65 @@
+# Gym Leader Shuffle
+
+
+
+Gym Leader Shuffle creates a persistent per-save derangement of the eight Kanto Gym Leaders. The visiting leader supplies the overworld sprite, portrait, introductory dialogue, and a team scaled to the physical gym. The gym itself retains its original badge, TM, rewards, defeat wording, progression flag, and trainer-deactivation behavior.
+
+
+
+## What it changes
+
+
+
+- Each new mapping assigns every Kanto Gym Leader to a different gym, with no leader remaining in their original gym.
+- 
+- The leader’s team is adjusted to the destination gym’s level curve, including evolution or de-evolution where necessary.
+- 
+- **SHUFFLE GYM TRAINERS** optionally applies the visiting leader’s non-leader gym-trainer roster to that gym while preserving its intended level curve.
+- 
+- **RANDOMIZE MOVE SETS**, **PREFER GYM-TYPE MOVES**, **ALLOW NATIVE STAB MOVES**, and **ENSURE A DAMAGING MOVE** control the optional move-set generator.
+- 
+- **OPEN SPOILER LOG** displays the eight saved leader-to-badge assignments.
+- 
+- **GYM TELEPORT (TEST)** and **RETURN TO LAST POINT (TEST)** are one-shot testing utilities for navigating the next eligible gym and returning to the original location.
+- 
+
+
+Giovanni’s Rocket Hideout and Silph Co. appearances are not shuffled; only his Viridian Gym appearance participates.
+
+
+
+## Install
+
+
+
+1. Download `gym_leader_shuffle-0.0.1.zip` from the source repository’s Releases page.
+2. 
+2. In Gen 1 Recomp, open **MODS** and select **Import mod .zip**.
+3. 
+3. Enable the mod and start a New Game, or load a save before entering a Kanto gym to create its persistent mapping.
+4. 
+
+
+## Compatibility
+
+
+
+Gym Leader Shuffle uses Mod API 2 with the `content` profile and does not affect link play. It has no declared dependencies or conflicts. It contains no ROM-derived content.
+
+
+
+## License
+
+
+
+Gym Leader Shuffle is distributed under the MIT License. See the source repository for the full license text.
+
+
+
+
+
+
+
+
+
+

--- a/mods/inmento@gym_leader_shuffle/meta.json
+++ b/mods/inmento@gym_leader_shuffle/meta.json
@@ -1,0 +1,53 @@
+{
+  
+  "id": "gym_leader_shuffle",
+  
+  "title": "Gym Leader Shuffle",
+  
+  "author": "inmento",
+  
+  "summary": "Shuffles the eight Kanto Gym Leaders per save while preserving each physical gym’s badge, TM, rewards, and progression.",
+  
+  "version": "0.0.1",
+  
+  "categories": ["GAMEPLAY"],
+  
+  "tags": ["kanto", "gym leaders", "shuffle", "trainer teams", "spoiler log"],
+  
+  "repo": "https://github.com/inmento/Gym-Leader-Shuffle",
+  
+  "github": "inmento/Gym-Leader-Shuffle",
+  
+  "automatic_version_check": true,
+  
+  "api": 2,
+  
+  "games": ["gen1"],
+  
+  "profile": "content",
+  
+  "affects_link": false,
+  
+  "permissions": ["engine_internals"],
+  
+  "license": "MIT"
+  
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
**Mod:** Gym Leader Shuffle v0.0.1 by @inmento
**Folder:** `mods/inmento@gym_leader_shuffle/`
**Source:** https://github.com/inmento/Gym-Leader-Shuffle

- [x] `modkit.py validate gym_leader_shuffle --strict` and `modkit.py lint gym_leader_shuffle` pass
- [x] The distributed `.zip` has the mod's files at the archive root
- [x] Nothing distributed is ROM-derived
- [x] `meta.json` matches `manifest.json` for id, API, profile, permissions, dependencies, and conflicts
- [x] This PR only touches `mods/inmento@gym_leader_shuffle/`

The entry uses GitHub release tracking with `automatic_version_check: true`.