### PR TITLE
feat: add TLoZ Recomp Mania 0.1.0

### DIFF
--- a/mods/castdrian@tloz-recomp-mania/description.md
+++ b/mods/castdrian@tloz-recomp-mania/description.md
@@ -1,0 +1,32 @@
+# TLoZ: Recomp Mania
+
+The Legend of Zelda, sort of?
+
+TLoZ: Recomp Mania replaces the player with Link and adds a Zelda-inspired action layer to gen1recomp.
+
+## What it changes
+
+- Link's Awakening DX Link movement, sword, shield, charge, and spin sprites.
+- Sword combos on B and a held-A shield stance.
+- Select-cycled equipment actions for the overworld.
+- Minish Cap action and movement sounds, plus Minecraft villager hit and death sounds for NPC combat.
+- Red NPC damage feedback and immediate three-hit defeats with particle bursts.
+
+## Install
+
+1. Download `tloz-recomp-mania-0.1.0.zip` from the [release page](https://github.com/castdrian/tloz-recomp-mania/releases/tag/v0.1.0).
+2. In the launcher, choose MODS → **Import mod .zip**.
+3. Enable the mod and start or load an overworld save.
+
+With GitHub release tracking enabled, the launcher can offer future updates from the mod repository.
+
+## Compatibility
+
+- Mod API 2.
+- Engine `>=0.0.0-0 <2.0.0`.
+- Overhaul profile; it changes the player and overworld combat feedback.
+- Supports the Gen 1 and Gen 2 data profiles declared by the mod.
+
+## Credits
+
+Link sprites are from the supplied Link's Awakening DX sprite sheet. Action audio is from the Minish Cap sound set, and NPC feedback uses the supplied Minecraft villager sounds.

--- a/mods/castdrian@tloz-recomp-mania/meta.json
+++ b/mods/castdrian@tloz-recomp-mania/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "tloz-recomp-mania",
+  "title": "TLoZ: Recomp Mania",
+  "author": "castdrian",
+  "version": "0.1.0",
+  "categories": ["GAMEPLAY", "ART", "AUDIO"],
+  "repo": "https://github.com/castdrian/tloz-recomp-mania",
+  "summary": "The Legend of Zelda, sort of?",
+  "tags": ["zelda", "link", "sword", "shield", "audio"],
+  "github": "castdrian/tloz-recomp-mania",
+  "automatic_version_check": true,
+  "api": 2,
+  "profile": "overhaul",
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "games": ["gen1", "gen2"],
+  "affects_link": true,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}


### PR DESCRIPTION
## What changed

Adds the `castdrian@tloz-recomp-mania` listing for TLoZ: Recomp Mania at version 0.1.0.

The entry links to the source repository and its `v0.1.0` release, enables automatic release tracking, and describes the Link sprites, Zelda-inspired actions, Minish Cap audio, and NPC combat feedback.

## Validation

- `node scripts/validate.mjs mods/castdrian@tloz-recomp-mania`
- `node scripts/validate.mjs`
- The source repository has a published `v0.1.0` release with an installable ZIP at the archive root.
