### PR TITLE
Add all public inmento mods to index

### DIFF
--- a/mods/inmento@gym_leader_shuffle/description.md
+++ b/mods/inmento@gym_leader_shuffle/description.md
@@ -1,0 +1,15 @@
+# Gym Leader Shuffle
+
+Gym Leader Shuffle randomizes which Gym Leader appears at each physical gym in **Pokémon Red, Blue, Yellow, and Gold**. The location itself keeps its intended badge, reward, progression gate, and level curve, while the visiting leader brings the appropriate presentation and battle identity.
+
+## Features
+
+The mod supports Kanto and Johto leader pools, leader-specific intro text, gym-specific defeat text and rewards, optional gym-trainer shuffling, a spoiler log, and testing-oriented gym teleports with a return-point safeguard. The randomizer is optional: the mod works on its own and also includes compatibility precautions for supported Crystal 251 installations.
+
+## Install
+
+Download the newest `gym_leader_shuffle-<version>.zip` from the [release page](https://github.com/inmento/Gym-Leader-Shuffle/releases). In Gen1Recomp, open **MODS**, choose **Import mod .zip**, import the archive, and enable the mod.
+
+## Compatibility
+
+Gym Leader Shuffle targets Mod API 2 and supports Gen 1 and Gold. It requires the `engine_internals` permission for its battle, text, and presentation integrations. It does not require a separate randomizer or starter mod.

--- a/mods/inmento@gym_leader_shuffle/meta.json
+++ b/mods/inmento@gym_leader_shuffle/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "gym_leader_shuffle",
+  "title": "Gym Leader Shuffle",
+  "author": "inmento",
+  "summary": "Shuffle Gym Leaders across Kanto and Johto while each physical gym keeps its own badge, reward, progression, and level curve.",
+  "version": "1.0.6",
+  "categories": ["GAMEPLAY", "QOL"],
+  "tags": ["gyms", "leaders", "kanto", "johto", "shuffle", "gold"],
+  "repo": "https://github.com/inmento/Gym-Leader-Shuffle",
+  "github": "inmento/Gym-Leader-Shuffle",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.99",
+  "games": ["gen1", "gen2"],
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"]
+}

--- a/mods/inmento@item_randomizer/description.md
+++ b/mods/inmento@item_randomizer/description.md
@@ -1,0 +1,17 @@
+# Item Randomizer
+
+Item Randomizer creates a persistent per-save item mapping for supported sources in **Pokémon Red, Blue, Yellow, and Gold**. Its ordinary pools exclude key items, HMs, non-tossable items, and other progression-sensitive rewards.
+
+## Features
+
+Players can independently enable visible item balls, hidden finds, shops, berries, eligible scripted gifts, eligible existing held items, and the protected New Game PC reward. Reduced low-value weighting and progression-aware weighting keep ordinary rewards useful while retaining the possibility of an early lucky find. Shop inventories and prices remain persistent per shop after generation.
+
+In Gen 1, **REROLL NEW GAME PC ITEM** is a one-shot action for the generated PC item: it rerolls the item, resets itself, returns to the overworld, and permanently locks only after the initialized contents have left the PC. The manual PC-item selector is Gold-only.
+
+## Install
+
+Download the newest `item_randomizer-<version>.zip` from the [release page](https://github.com/inmento/Item-Randomizer/releases). In Gen1Recomp, open **MODS**, choose **Import mod .zip**, import the archive, and enable the mod.
+
+## Compatibility
+
+The mod targets API 2 and supports Gen 1 and Gold. It uses the active game version to keep Gen 1 and Gold option paths separate, and includes safe dynamic filtering for supported Crystal 251 installations.

--- a/mods/inmento@item_randomizer/meta.json
+++ b/mods/inmento@item_randomizer/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "item_randomizer",
+  "title": "Item Randomizer",
+  "author": "inmento",
+  "summary": "Persistent, progression-aware randomization for safe item sources, shops, berries, gifts, eligible held items, and New Game PC choices.",
+  "version": "1.0.10",
+  "categories": ["GAMEPLAY", "QOL"],
+  "tags": ["items", "shops", "randomizer", "weighted loot", "berries", "gold"],
+  "repo": "https://github.com/inmento/Item-Randomizer",
+  "github": "inmento/Item-Randomizer",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.99",
+  "games": ["gen1", "gen2"],
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"]
+}

--- a/mods/inmento@randomized_gym_challenge/description.md
+++ b/mods/inmento@randomized_gym_challenge/description.md
@@ -1,0 +1,17 @@
+# Randomized Gym Challenge
+
+Randomized Gym Challenge is a configurable gym-battle generator for **Pokémon Red, Blue, Yellow, and Gold**. It can randomize leaders, teams, levels, movesets, and eligible held items while allowing players to choose how much of each gym’s original identity to preserve.
+
+## Features
+
+Options include type-theme preservation, evolution-stage enforcement, level ranges based on each gym’s intended progression, and independent rules for leader and gym-trainer teams. Every gameplay-changing setting starts disabled.
+
+The optional **Gym Challenge** mode provides milestone-gated progression through the gyms, recovery-aware challenge controls, weighted Gym Guide rewards, summaries, hints, presets, and a Gold two-league flow. It is designed as a separate game mode rather than a requirement for ordinary randomized gyms.
+
+## Install
+
+Download the newest `randomized_gym_challenge-<version>.zip` from the [release page](https://github.com/inmento/Randomized-Gym-Challenge/releases). In Gen1Recomp, open **MODS**, choose **Import mod .zip**, import the archive, and enable the mod.
+
+## Compatibility
+
+The mod targets API 2 and supports Gen 1 and Gold. It conflicts with **Gym Leader Shuffle**, since both modify gym-leader and gym-battle behavior; enable only one of those two mods at a time. It also includes compatibility precautions for supported Crystal 251 installations.

--- a/mods/inmento@randomized_gym_challenge/meta.json
+++ b/mods/inmento@randomized_gym_challenge/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "randomized_gym_challenge",
+  "title": "Randomized Gym Challenge",
+  "author": "inmento",
+  "summary": "Configurable randomized gym battles and an optional milestone-gated Gym Challenge mode for Kanto and Johto.",
+  "version": "1.1.2",
+  "categories": ["GAMEPLAY", "QOL"],
+  "tags": ["gyms", "challenge mode", "randomizer", "leaders", "kanto", "johto", "gold"],
+  "repo": "https://github.com/inmento/Randomized-Gym-Challenge",
+  "github": "inmento/Randomized-Gym-Challenge",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.99",
+  "games": ["gen1", "gen2"],
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "conflicts": ["gym_leader_shuffle"]
+}

--- a/mods/inmento@sound_effect_replacer/description.md
+++ b/mods/inmento@sound_effect_replacer/description.md
@@ -1,0 +1,19 @@
+# Sound Effect Replacer
+
+Sound Effect Replacer lets players replace selected audio in **Pokémon Red, Blue, Yellow, and Gold** through a simple two-folder layout: **General Sound Effects** for common categories and **Specific Sound Effects** for exact control.
+
+## Features
+
+The mod exposes every current named engine sound-effect label, optional move sounds for all 251 move IDs, evolution in-progress and completion audio, species cries, and all 42 special Yellow Pikachu voice clips. A single shared folder works for a cue in whichever supported game is currently running.
+
+Replacement files can use the formats decoded by the bundled LÖVE runtime, including WAV, MP3, FLAC, Ogg Vorbis, and supported tracker/module formats. Ogg Opus is detected and skipped with a diagnostic warning because it is not supported by the runtime.
+
+The optional PotatoVoxel integration uses an original Lua-authored chip confirmation cue only when that mod is enabled; it remains silent otherwise.
+
+## Install
+
+Download the newest `sound_effect_replacer-<version>.zip` from the [release page](https://github.com/inmento/Sound-Effect-Replacer/releases). In Gen1Recomp, open **MODS**, choose **Import mod .zip**, import the archive, and enable the mod.
+
+## Compatibility
+
+Sound Effect Replacer targets API 2 and supports Gen 1 and Gold. Replacement audio is configured per player by placing one supported file in the desired existing target folder and restarting Gen1Recomp.

--- a/mods/inmento@sound_effect_replacer/meta.json
+++ b/mods/inmento@sound_effect_replacer/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "sound_effect_replacer",
+  "title": "Sound Effect Replacer",
+  "author": "inmento",
+  "summary": "Replace selected named effects, move sounds, evolution audio, cries, and Yellow Pikachu voice clips with player-supplied audio in Gen 1 and Gold.",
+  "version": "0.3.2",
+  "categories": ["AUDIO", "QOL"],
+  "tags": ["audio", "sound effects", "cries", "evolution", "moves", "gold"],
+  "repo": "https://github.com/inmento/Sound-Effect-Replacer",
+  "github": "inmento/Sound-Effect-Replacer",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.99",
+  "games": ["gen1", "gen2"],
+  "profile": "content",
+  "permissions": ["engine_internals"]
+}

--- a/mods/inmento@starter_picker/description.md
+++ b/mods/inmento@starter_picker/description.md
@@ -1,0 +1,17 @@
+# Starter Picker
+
+Starter Picker lets players configure the Pokémon in each original starter-ball position while preserving the game’s intended rival counter-pick relationship. It supports all 151 Gen 1 species and all 251 Gold species.
+
+## Features
+
+Gen 1 supports Oak’s Lab, player-only maximum DVs, and a dedicated in-game 151-species browser under **START > OPTIONS**. Gold supports Elm’s Lab, configured-species dialogue and presentation, player-only Preserve, Max, Random, and legal Shiny DV modes, plus named or weighted starter held-item choices.
+
+The mod can recognize supported Gen 1 and Gold Randomizer configurations and synchronize active assignments when available. A deliberate Starter Picker change afterward remains authoritative. The rival prefers a starter super-effective against the player’s final choice, avoids candidates the player defeats super-effectively when no direct weakness exists, and otherwise chooses randomly. Rival DVs and held items are not changed by player-only settings.
+
+## Install
+
+Download the newest `starter_picker-<version>.zip` from the [release page](https://github.com/inmento/Starter-Picker/releases). In Gen1Recomp, open **MODS**, choose **Import mod .zip**, import the archive, and enable the mod.
+
+## Compatibility
+
+Starter Picker targets API 2 and supports Gen 1 and Gold. It uses the active game version to select the Oak’s Lab or Elm’s Lab branch, and includes compatibility precautions for supported Crystal 251 installations.

--- a/mods/inmento@starter_picker/meta.json
+++ b/mods/inmento@starter_picker/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "starter_picker",
+  "title": "Starter Picker",
+  "author": "inmento",
+  "summary": "Choose player starters in Gen 1 and Gold while retaining rival counter-picks, in-game selection, safe held-item themes, and optional trade-evolution help.",
+  "version": "1.0.8",
+  "categories": ["GAMEPLAY", "QOL"],
+  "tags": ["starters", "oak lab", "elm lab", "dvs", "held items", "gold"],
+  "repo": "https://github.com/inmento/Starter-Picker",
+  "github": "inmento/Starter-Picker",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.99",
+  "games": ["gen1", "gen2"],
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"]
+}


### PR DESCRIPTION
## Consolidated inmento mod submission

This single request adds all five current public inmento mods to the index:

- Gym Leader Shuffle 1.0.6
- - Item Randomizer 1.0.10
- - Starter Picker 1.0.8
- - Randomized Gym Challenge 1.1.2
- - Sound Effect Replacer 0.3.2
Each entry uses the current public manifest metadata and GitHub repository for automatic release-version tracking. Randomized Gym Challenge declares its existing conflict with Gym Leader Shuffle.

- [x] Index schema validation passes for all five entries.
- [ ] - [x] Each current distributed ZIP has its mod files at the archive root.
- [ ] - [x] Each ZIP manifest matches the corresponding `meta.json` id and version.
- [ ] - [x] The entries declare manifest permissions and conflicts.
- [ ] - [x] This PR only adds `mods/inmento@<id>/` entries.
- [ ] 