### PR TITLE
Add what-the-heck translation mod

### DIFF
--- a/mods/adrian@what-the-heck/description.md
+++ b/mods/adrian@what-the-heck/description.md
@@ -1,0 +1,7 @@
+# what-the-heck
+
+what the heck is this?
+
+This content mod runs Pokémon Red, Blue, Yellow, and Gold text through a forty-language translation relay and translates it back to English. Dialogue, menus, battle text, signs, Pokémon names, move names, item names, trainer names, and engine-authored strings all receive the same nonsense translation treatment.
+
+The generated catalogs are packaged with the mod, so it does not need network access at runtime and does not include ROMs or save files. Runtime controls, placeholders, record identifiers, and game text boundaries are validated before packaging.

--- a/mods/adrian@what-the-heck/meta.json
+++ b/mods/adrian@what-the-heck/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "what-the-heck",
+  "title": "what-the-heck",
+  "author": "adrian",
+  "summary": "what the heck is this?",
+  "version": "0.1.0",
+  "categories": [
+    "TRANSLATION"
+  ],
+  "tags": [
+    "translation",
+    "back-translation",
+    "nonsense",
+    "pokemon"
+  ],
+  "repo": "https://github.com/castdrian/what-the-heck",
+  "github": "castdrian/what-the-heck",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-dev <2.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow",
+    "gold"
+  ],
+  "profile": "content",
+  "permissions": [],
+  "dependencies": [],
+  "conflicts": []
+}


### PR DESCRIPTION
Adds the what-the-heck listing for the v0.1.0 release.

The entry tracks https://github.com/castdrian/what-the-heck automatically and points to its installable what-the-heck-0.1.0.zip release asset. The listing describes the forty-language back-translation treatment across Red, Blue, Yellow, and Gold.

Validation:
- node scripts/validate.mjs mods/adrian@what-the-heck
- Published release asset resolves successfully.
