### PR TITLE
Add Floating Battle HUD 0.7.5

### DIFF
--- a/mods/Bass@FLOATING_BATTLE_HUD/description.md
+++ b/mods/Bass@FLOATING_BATTLE_HUD/description.md
@@ -1,0 +1,10 @@
+• The HUD follows, scales, and rotates with the camera.
+• Numeric HP display.
+• Capture icon for already registered Pokémon.
+• Status icon.
+• Experience bar.
+• Full floating battle command menu with FIGHT / PKMN / ITEM / RUN.
+• Custom ITEM menu, is filtered and sorted to show only battle-usable items.
+• Custom battle message boxes with camera-responsive 3D perspective.
+
+• Optional: Display DVs below the HUD for wild Pokémon (HP/Atk/Def/Spd/Spe format).

--- a/mods/Bass@FLOATING_BATTLE_HUD/meta.json
+++ b/mods/Bass@FLOATING_BATTLE_HUD/meta.json
@@ -1,0 +1,30 @@
+{
+  "id": "FLOATING_BATTLE_HUD",
+  "title": "Floating Battle HUD",
+  "author": "Bass",
+  "version": "0.7.5",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/bass-dv/g1rFloatingBattleHUD/",
+  "summary": "Immersive floating battle HUD and menus for VOXEL mods.",
+  "tags": [
+    "ui",
+    "voxel",
+    "qol",
+    "battle"
+  ],
+  "github": "atingBatbass-dv/g1rFlotleHUD",
+  "game_version": ">=0.1.37",
+  "license": "MIT",
+  "dependencies": [
+    "DRAMATIC_SHAPE",
+    "POTATO_VOXEL"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "overhaul"
+}


### PR DESCRIPTION
Adds `mods/Bass@FLOATING_BATTLE_HUD/` — **Floating Battle HUD** 0.7.5 by Bass.

- Source: https://github.com/bass-dv/g1rFloatingBattleHUD/
- Releases tracked from: `atingBatbass-dv/g1rFlotleHUD`
- Categories: UI, QOL
- Profile: `overhaul`, mod API 2

Author checklist:

- [x] `modkit.py validate --strict` and `modkit.py lint` pass
- [x] the distributed archive contains no ROM-derived content
- [x] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>