### PR TITLE
Add  Gen2 Tradução PT-BR Gold & Silver

### DIFF
--- a/mods/LordSangreal@versaodourada/description.md
+++ b/mods/LordSangreal@versaodourada/description.md
@@ -1,0 +1,107 @@
+# Versao Dourada
+
+**Pokemon Gold e Silver em portugues brasileiro, num download so.** O mod
+reconhece qual cartucho esta rodando e usa a POKeDEX daquela versao.
+
+Roda em dois motores a partir do mesmo pacote: `gen1recomp` e
+[Gen2Recomped](https://github.com/UNDERdecoded/Gen2Recomped).
+
+Nao acompanha nenhum byte de ROM. **Todo o texto e traducao propria, escrita a
+partir do ingles original de cada versao** -- nao ha uma linha derivada de
+outra traducao no pacote.
+
+## Quanto chega a tela
+
+| | so o mod | com o patch de motor |
+|---|---|---|
+| **Total** | **90%** | **97%** |
+
+Sao 5312 entradas medidas por jogo. So com o mod instalado o jogo ja fica
+jogavel e majoritariamente em portugues: falas de NPC, golpes, itens, tipos,
+classes de treinador, nomes de lugar e tres quartos dos menus.
+
+| categoria | total | so o mod | com o patch |
+|---|---|---|---|
+| Falas de NPC | 2994 | 2994 | 2994 |
+| Menus e batalha | 1085 | 791 | 933 |
+| POKeDEX | 251 | 0 | 251 |
+| Nomes e descricoes de golpe | 504 | 504 | 504 |
+| Nomes e descricoes de item | 325 | 325 | 325 |
+| Classes de treinador | 66 | 66 | 66 |
+| Nomes de lugar | 70 | 70 | 70 |
+| Nomes de tipo | 17 | 17 | 17 |
+
+**Nada quebra sem o patch.** Uma chave que o motor nao pede simplesmente nao e
+usada, e um registro sem rota e pulado. O que nao chega **aparece em ingles**,
+nunca em branco nem cortado.
+
+O que depende do patch e a **POKeDEX inteira** (o motor de fabrica ainda nao
+tem a rota de catalogo que entrega as fichas) e 152 rotulos de menu e batalha.
+Esse patch e um PR pendente no `gen1recomp`, escrito e testado, e pode nao ser
+aceito -- por isso os dois numeros aparecem separados aqui.
+
+## Gold e Silver no mesmo pacote
+
+O texto de NPC e **identico** nas duas ROMs -- 3134 falas, zero diferentes --,
+e itens, golpes, lugares e treinadores tambem. So oito falas mudam de endereco,
+e o catalogo carrega as duas chaves.
+
+A POKeDEX e a excecao: as 251 especies tem ficha propria em cada versao, e as
+502 descricoes do Silver foram escritas do zero a partir do ingles daquela ROM.
+Quem responde qual jogo esta rodando e a propria ROM -- ENTEI e TYRANITAR tem a
+altura trocada entre as versoes, a unica diferenca numerica entre as duas
+fichas.
+
+## Duas coisas voce escolhe
+
+Em **MODS -> Versao Dourada -> OPTIONS**:
+
+| linha | escolhas | o que muda |
+|---|---|---|
+| NOME DOS GOLPES | PORTUGUES / ENGLISH | so o **nome** do golpe |
+| NOME DOS ITENS | PORTUGUES / ENGLISH | so o **nome** do item |
+
+Sao os nomes, e so eles: a descricao do golpe, da TM e do item continua em
+portugues nos dois modos. As duas existem porque quem joga com guia aberto quer
+o nome que o guia usa.
+
+**A troca vale no proximo boot** -- o mod decide no carregamento o que
+registrar. Com o patch a propria tela avisa (`RESTART TO APPLY`); sem ele a
+escolha funciona igual, so o aviso nao aparece.
+
+## O que fica no original, de proposito
+
+**Nomes de POKeMON** (BULBASAUR, GYARADOS), **nomes de personagem** (LANCE,
+WHITNEY) e as siglas **TM/HM**. Sao os nomes oficiais no mundo inteiro,
+inclusive nos jogos em portugues, e traduzi-los quebraria a comunicacao com
+qualquer guia, video ou amigo.
+
+**Cidade, Rota e Vila traduzem a palavra generica**, mantendo o nome proprio:
+"VIOLET CITY" -> "CIDADE DE VIOLET", "ROUTE 30" -> "ROTA 30". Pontos que nao
+sao cidade, vila ou rota (SPROUT TOWER, UNION CAVE) ficam inteiros em ingles.
+
+**A interface do aplicativo** -- launcher, importacao de ROM, espacos de save,
+gerenciador de mods -- fica em ingles por largura: ali os botoes tem tamanho
+fixo e o portugues, mais longo, saia cortado.
+
+A terminologia segue a localizacao oficial em portugues do Brasil, com a
+**carta de TCG pt-BR** como fonte primaria para golpes e itens (GRANDE BOLA, e
+nao "Otima Bola", que e do Pokemon GO). Altura e peso da POKeDEX aparecem em
+**metro e quilo**, e o numero vem da tabela canonica da franquia, nao de
+converter a libra de volta.
+
+## Acentuacao
+
+A fonte da ROM internacional so tem tres caracteres acentuados uteis, entao o
+mod acrescenta uma **pagina propria de 25 glifos** acima das paginas da ROM --
+acrescenta, nao substitui. Cada letra acentuada vale exatamente uma coluna de
+texto, como qualquer outra.
+
+## Joga Crystal?
+
+E outro mod:
+[versaocristal-ptbr](https://github.com/LordSangreal/versaocristal-ptbr). Ali
+as falas de NPC realmente divergem das do Gold -- centenas de rotulos existem
+nos dois jogos com texto diferente --, e um catalogo unico mostrava a fala do
+jogo errado. Entre Gold e Silver isso nao acontece, e por isso os dois cabem
+aqui.

--- a/mods/LordSangreal@versaodourada/meta.json
+++ b/mods/LordSangreal@versaodourada/meta.json
@@ -1,9 +1,9 @@
 {
   "id": "versaodourada",
-  "title": "Gen2 Tradução PT-BR  Gold & Silver 0.52.0",
+  "title": "Gen2 Tradução PT-BR  Gold & Silver 0.53.0",
   "author": "LordSangreal",
   "summary": "Pokémon Gold e Silver em português brasileiro, num download só: a POKéDEX troca sozinha conforme o jogo. Tradução própria, escrita do inglês original de cada versão.",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "categories": [
     "TRANSLATION"
   ],

--- a/mods/LordSangreal@versaodourada/meta.json
+++ b/mods/LordSangreal@versaodourada/meta.json
@@ -1,0 +1,33 @@
+{
+  "id": "versaodourada",
+  "title": "Gen2 Tradução PT-BR  Gold & Silver 0.51.0",
+  "author": "LordSangreal",
+  "summary": "Pokémon Gold e Silver em português brasileiro, num download só: a POKéDEX troca sozinha conforme o jogo. Tradução própria, escrita do inglês original de cada versão.",
+  "version": "0.51.0",
+  "categories": [
+    "TRANSLATION"
+  ],
+  "tags": [
+    "portugues",
+    "brasileiro",
+    "portuguese",
+    "brazilian",
+    "traducao",
+    "gold",
+    "silver",
+    "gen2"
+  ],
+  "repo": "https://github.com/LordSangreal/versaodourada",
+  "github": "LordSangreal/versaodourada",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "games": [
+    "gold",
+    "gen2"
+  ],
+  "profile": "content",
+  "permissions": [],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/LordSangreal@versaodourada/meta.json
+++ b/mods/LordSangreal@versaodourada/meta.json
@@ -1,9 +1,9 @@
 {
   "id": "versaodourada",
-  "title": "Gen2 Tradução PT-BR  Gold & Silver 0.51.0",
+  "title": "Gen2 Tradução PT-BR  Gold & Silver 0.52.0",
   "author": "LordSangreal",
   "summary": "Pokémon Gold e Silver em português brasileiro, num download só: a POKéDEX troca sozinha conforme o jogo. Tradução própria, escrita do inglês original de cada versão.",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "categories": [
     "TRANSLATION"
   ],


### PR DESCRIPTION
**Mod:** Gen2 Tradução PT-BR  Gold & Silver  — by LordSangreal
**Folder:** `mods/LordSangreal@versaodourada/`
**Source:** https://github.com/LordSangreal/versaodourada

- [x] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/<Author>@<id>/`

---

Brazilian Portuguese for Pokémon **Gold and Silver in one download**. The mod reads which cartridge is running and applies that version's POKéDEX — the 251 species have their own entry text in each game, and both sets are translated. Everything else (NPC speech, items, moves, places, trainer classes) is byte-identical between the two ROMs, so a single catalog serves both.

It runs on `gen1recomp` and on the Gen2Recomped fork from the same package: the dialogue catalog carries each line under both key shapes, and a key the running engine does not ask for stays inert.

Every line is written from the original English of each ROM. No text is derived from another translation, and no ROM bytes ship in the package — the accented glyph page is the mod's own asset (`assets/font/latin.png`), added above the ROM's pages rather than replacing them.

**Coverage:** 90% of the translation reaches the screen on the stock engine. The remaining 7% needs an engine patch that is still an unsent PR, and nothing breaks without it — a key the engine does not request is simply not used, and what does not arrive shows in English, never blank or clipped. The listing describes the mod as it works today, on the stock engine.

### Notes on the checks

`modkit validate --strict` needed two things to actually run here, and I want them on the record rather than quietly assumed:

- **MK100** runs the mod in a headless loader driver under `luajit`, which this machine does not have as a binary. I ran it on the LuaJIT 2.1 that ships inside `lupa`, via `MODKIT_LUAJIT`. The loader driver comes back clean — no ignored mod, no orphan patch targets.
- **MK305** diffs `lang/font.lua` against the imported `data/generated/font.lua` to catch a bulk dump of a vanilla table, and warns rather than passes when there is nothing to diff against. With that table present the rule runs and passes: the mod's `font.lua` registers one added glyph page at `base = 0x100`, not a copy of the cart's.

`scan-lua.mjs` reports four "a human should read" lines. All four are the scanner matching the substring `require` where no call exists — twice inside `requires_restart = true` in `main.lua`, and twice inside the English word `required` used as a catalog key in `lang/strings.lua`. Nothing reaches past the sandbox.

Two fields differ from `manifest.json` on purpose: `categories` is `TRANSLATION` because the manifest's `LANGUAGE` is not in this schema's enum, and `games` is `["gold", "gen2"]` because `"silver"` is not an enum value here — the manifest declares `["gold", "silver"]`.

`license` is omitted rather than guessed: the mod repository does not declare one yet.
