### PR TITLE
Add five UI mods by ishhodaszi

### DIFF
--- a/mods/ishhodaszi@battle_info_hud/description.md
+++ b/mods/ishhodaszi@battle_info_hud/description.md
@@ -1,0 +1,11 @@
+# Battle Info HUD
+
+Battle Info HUD adds missing battle-reading information to Gen1Recomp's existing HUD while preserving its original panels, curves, font, and tiles.
+
+It redraws the native HP meters with clear green, yellow, and red states; extends the player panel with a slim EXP strip and progress readout; places the game's Poké Ball tile beside opponents whose species has already been caught; and gives status and level labels a cleaner shared alignment.
+
+The presentation adapts to classic, WIDE, and supported staged voxel battle layouts. Gender Mod markers are kept aligned with the adjusted player level row, and compatible staged renderers retain ownership of their world, sprites, and HUD placement.
+
+The mod changes presentation only. It does not alter stats, EXP gains, catches, status effects, battle rules, or ordinary save data. A **BATTLE INFO** setting in the normal Options menu restores the original minimal HUD at any time.
+
+The package contains no ROM-derived assets. It requires `engine_internals` so it can augment Gen1Recomp's built-in battle renderer and reuse its native font and HUD tiles.

--- a/mods/ishhodaszi@battle_info_hud/meta.json
+++ b/mods/ishhodaszi@battle_info_hud/meta.json
@@ -1,0 +1,36 @@
+{
+  "id": "battle_info_hud",
+  "title": "Battle Info HUD",
+  "author": "ishhodaszi",
+  "version": "0.8.5",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/piftee/gen1recomp-battle-info-hud",
+  "summary": "Adds colour HP, EXP progress, caught markers, and clearer status and level labels to the existing native battle HUD.",
+  "tags": [
+    "ui",
+    "battle",
+    "quality-of-life",
+    "hud",
+    "exp",
+    "caught marker"
+  ],
+  "github": "piftee/gen1recomp-battle-info-hud",
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow"
+  ],
+  "profile": "content",
+  "experimental": false,
+  "permissions": [
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}

--- a/mods/ishhodaszi@modern_bag_ui/description.md
+++ b/mods/ishhodaszi@modern_bag_ui/description.md
@@ -1,0 +1,11 @@
+# Modern Bag UI
+
+Modern Bag UI rebuilds the bare item list as a responsive, pocket-based Bag while keeping Gen 1's font, palettes, sounds, and item behaviour.
+
+Alongside an **All** list in acquisition order, five pockets organise Items, Medicine, Poké Balls, TMs/HMs, and Key Items. Left and right switch pockets, each pocket remembers its cursor, and items can be safely reordered. The same design carries into the PC's Withdraw, Deposit, and Toss screens.
+
+Two skins are included: a colourful modern layout and a classic Pocket-style layout. Both adapt across compact 160×144 play, widescreen windows, and portrait phones, with readable details, quantities, money, and capacity. Item descriptions remain translatable through the engine's string catalogue.
+
+Gen1Recomp save files can hold up to 255 unique Bag and PC stacks with quantities up to x999. Exporting back to an original cartridge `.sav` still uses the hardware-era 20/50-stack and x99 limits, so overflow should be moved or reduced before export.
+
+Item use, party targeting, battle turns, TMs/HMs, fishing, bicycles, and scripted Bags continue to use the engine's built-in controller. The mod requires `engine_internals` to retain that behaviour while replacing the presentation and extending storage.

--- a/mods/ishhodaszi@modern_bag_ui/meta.json
+++ b/mods/ishhodaszi@modern_bag_ui/meta.json
@@ -1,0 +1,37 @@
+{
+  "id": "modern_bag_ui",
+  "title": "Modern Bag UI",
+  "author": "ishhodaszi",
+  "version": "0.4.1",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/piftee/gen1recomp-modern-bag-ui",
+  "summary": "Rebuilds the Bag and PC item lists as responsive pocket-based interfaces with expanded storage and two selectable skins.",
+  "tags": [
+    "ui",
+    "inventory",
+    "quality-of-life",
+    "responsive",
+    "mobile",
+    "bag",
+    "pc"
+  ],
+  "github": "piftee/gen1recomp-modern-bag-ui",
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow"
+  ],
+  "profile": "content",
+  "experimental": false,
+  "permissions": [
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}

--- a/mods/ishhodaszi@modern_party_ui/description.md
+++ b/mods/ishhodaszi@modern_party_ui/description.md
@@ -1,0 +1,11 @@
+# Modern Party UI
+
+Modern Party UI rebuilds the party screen and the built-in Pokémon summary pages with responsive cards while retaining Gen 1's font, sprites, cries, controls, and animated menu icons.
+
+Party members appear as chamfered, palette-tinted cards with aligned HP and EXP information, visible empty slots, selected types, and a strong focus frame. Landscape layouts expand into two useful columns; portrait phones use six full-width stacked cards. Compact 160×144 play remains supported.
+
+The responsive STATS and MOVES pages reorganise profile, status, experience, stats, moves, type, and PP information without changing the underlying Pokémon. Eight settings control card colour, value formats, EXP strips, empty slots, backdrop, widescreen use, and icon animation.
+
+Optional adapters let compatible mods contribute gender markers, DVs and Stat EXP, ribbons, shiny palettes, split Special stats, replacement menu icons, rename/follow actions, and additional summary behaviour. Modern Bag UI can also open the same full-height party target view on portrait displays.
+
+Field moves, switching, item targeting, TM/HM checks, healing, trades, callbacks, and cursor persistence remain owned by Gen1Recomp's normal controllers. The mod requires `engine_internals` to preserve those controllers while replacing their presentation.

--- a/mods/ishhodaszi@modern_party_ui/meta.json
+++ b/mods/ishhodaszi@modern_party_ui/meta.json
@@ -1,0 +1,37 @@
+{
+  "id": "modern_party_ui",
+  "title": "Modern Party UI",
+  "author": "ishhodaszi",
+  "version": "0.3.15",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/piftee/gen1recomp-modern-party-ui",
+  "summary": "Adds responsive type-coloured party and Pokémon summary cards built from Gen 1's own font, sprites, and UI assets.",
+  "tags": [
+    "ui",
+    "party",
+    "summary",
+    "quality-of-life",
+    "responsive",
+    "mobile",
+    "widescreen"
+  ],
+  "github": "piftee/gen1recomp-modern-party-ui",
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow"
+  ],
+  "profile": "content",
+  "experimental": false,
+  "permissions": [
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}

--- a/mods/ishhodaszi@modern_pc_ui/description.md
+++ b/mods/ishhodaszi@modern_pc_ui/description.md
@@ -1,0 +1,11 @@
+# Modern PC UI
+
+Modern PC UI turns Someone's PC into one direct-manipulation party-and-box workspace. It keeps Pokémon Red's pixel font, menu icons, palettes, cries, box capacity, and save format while making both sides of storage visible together.
+
+Press **A** to pick up, place, reorder, or swap a Pokémon. **SELECT** advances to the next box even while carrying one, and **START** opens Summary, one-step transfer, Release, and previous/next box actions. Empty party and box positions remain visible, and the usual full-party, full-box, and last-party-member safeguards are preserved.
+
+The layout supports compact 160×144 play and responsive widescreen displays, where a selected-Pokémon detail rail and named party cards use the available room. Primary-type colours and styling match Modern Party UI.
+
+Compatible icon, gender, rename, follower, DV, ribbon, shiny, split-stat, and summary mods retain their live integrations. Modern Bag UI and Modern Party UI are optional companions rather than dependencies.
+
+Native saving, summaries, cries, boxed-stat refresh, release rules, and Pokémon Yellow's deposited-Pikachu happiness behaviour stay intact. The mod requires `engine_internals` so it can preserve those engine behaviours inside the new presentation.

--- a/mods/ishhodaszi@modern_pc_ui/meta.json
+++ b/mods/ishhodaszi@modern_pc_ui/meta.json
@@ -1,0 +1,37 @@
+{
+  "id": "modern_pc_ui",
+  "title": "Modern PC UI",
+  "author": "ishhodaszi",
+  "version": "0.1.3",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/piftee/gen1recomp-modern-pc-ui",
+  "summary": "Turns Someone's PC into one responsive party-and-box workspace with direct pickup, drop, swap, and quick transfers.",
+  "tags": [
+    "ui",
+    "storage",
+    "pc",
+    "party",
+    "quality-of-life",
+    "responsive",
+    "boxes"
+  ],
+  "github": "piftee/gen1recomp-modern-pc-ui",
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow"
+  ],
+  "profile": "content",
+  "experimental": false,
+  "permissions": [
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}

--- a/mods/ishhodaszi@typed_move_colors/description.md
+++ b/mods/ishhodaszi@typed_move_colors/description.md
@@ -1,0 +1,11 @@
+# Typed Move Colors
+
+Typed Move Colors can turn each move into a chamfered type-coloured card or leave the native interface intact and colour only its move-name text. Both presentations retain Pokémon Red, Blue, and Yellow's original font and read the live merged move registry, so renamed moves, balance changes, and custom types are respected.
+
+Colours appear in battle move selection, Pokémon summaries, move forgetting, Mimic, and PP-item targeting. Responsive battle cards include full type, Power, PP, and optional effectiveness indicators. They adapt to classic, WIDE, high-DPI, short landscape, and portrait-safe layouts without replacing the battlefield, sprites, or status HUD.
+
+Text Only mode restores the active renderer's original boxes, cursor, PP panel, and controls, then adds brighter move-name and selected-type ink. Settings also control battle and menu coverage, wide or game layout, effectiveness hints, soft/bold/vibrant palettes, and card opacity.
+
+Compatibility paths preserve the presentations supplied by popular modern UI and staged battle mods while adding type information where they expose suitable hooks. Unknown custom types use a neutral fallback.
+
+The mod changes presentation only and requires `engine_internals` to augment Gen1Recomp's existing battle and menu drawing without replacing move behaviour.

--- a/mods/ishhodaszi@typed_move_colors/meta.json
+++ b/mods/ishhodaszi@typed_move_colors/meta.json
@@ -1,0 +1,37 @@
+{
+  "id": "typed_move_colors",
+  "title": "Typed Move Colors",
+  "author": "ishhodaszi",
+  "version": "0.4.0",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/piftee/gen1recomp-typed-move-colors",
+  "summary": "Adds responsive type-coloured move cards or native-layout move-name colours across battles, summaries, and move pickers.",
+  "tags": [
+    "ui",
+    "moves",
+    "battle",
+    "types",
+    "quality-of-life",
+    "responsive",
+    "accessibility"
+  ],
+  "github": "piftee/gen1recomp-typed-move-colors",
+  "api": 2,
+  "game_version": ">=0.0.0-dev <1.0.0",
+  "games": [
+    "red",
+    "blue",
+    "yellow"
+  ],
+  "profile": "content",
+  "experimental": false,
+  "permissions": [
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Adds community-index entries for five Gen1Recomp UI and quality-of-life mods:

- Battle Info HUD
- Modern Bag UI
- Modern Party UI
- Modern PC UI
- Typed Move Colors

Each entry mirrors its published release manifest, links the dedicated source and release repository, and includes a concise long-form description. Automatic GitHub release tracking is enabled through each github field.

## Validation

- `node scripts/validate.mjs` — 5 entries, 0 warnings
- duplicate and blocklist checks — clean
- release and repository link checks — installable
- release sandbox scan — nothing reaches past the sandbox
- `modkit.py validate --strict` — all five published packages valid
- `modkit.py lint` — no ROM-derived content detected in any package