### PR TITLE
Add PixelGen1 Font to mod index

### DIFF
--- a/mods/ShaneMcGovernIE@gen1_font_replacer/description.md
+++ b/mods/ShaneMcGovernIE@gen1_font_replacer/description.md
@@ -1,0 +1,13 @@
+# PixelGen1 Font
+
+PixelGen1 Font replaces the game's ordinary text with Pixelify Sans Gen1, a
+Gen 1-style proportional font designed to keep narrow letters from creating
+oversized gaps.
+
+It refines the `1`, `2`, `5`, and `7` glyphs, cleans up lowercase `e`, `p`, and
+`y`, keeps one-pixel spacing between status-screen lines, and centers the
+summary-screen next-EXP value.
+
+The mod includes Pixelify Sans Gen1 by default and supports additional `.ttf`
+and `.otf` fonts through its options. It targets Gen 1 games and is available
+from the [PixelGen1 Font releases page](https://github.com/ShaneMcGovernIE/PixelGen1_Font/releases).

--- a/mods/ShaneMcGovernIE@gen1_font_replacer/meta.json
+++ b/mods/ShaneMcGovernIE@gen1_font_replacer/meta.json
@@ -1,0 +1,26 @@
+{
+  "id": "gen1_font_replacer",
+  "title": "PixelGen1 Font",
+  "author": "ShaneMcGovernIE",
+  "version": "1.1.8",
+  "categories": [
+    "UI"
+  ],
+  "summary": "A Gen 1-style proportional font with refined glyphs, cleaner spacing, and centered summary-screen next EXP.",
+  "tags": [
+    "font",
+    "pixel art",
+    "gen 1",
+    "spacing"
+  ],
+  "repo": "https://github.com/ShaneMcGovernIE/PixelGen1_Font",
+  "github": "ShaneMcGovernIE/PixelGen1_Font",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "games": [
+    "gen1"
+  ],
+  "profile": "content",
+  "affects_link": false
+}


### PR DESCRIPTION
Adds `mods/ShaneMcGovernIE@gen1_font_replacer/` for **PixelGen1 Font** 1.1.8 by ShaneMcGovernIE.

- Source: https://github.com/ShaneMcGovernIE/PixelGen1_Font
- Releases tracked from: `ShaneMcGovernIE/PixelGen1_Font`
- Category: `UI`
- Profile: `content`, mod API 2
- Supports Gen 1 games

Validation completed:

- [x] `modkit.py validate --strict` passes
- [x] `modkit.py lint` passes
- [x] Release ZIP is installable with mod files at the archive root
- [x] No ROM-derived content is included