### PR TITLE
Add GameShark Compatibility

### DIFF
--- a/mods/goofwear@GameShark/description.md
+++ b/mods/goofwear@GameShark/description.md
@@ -1,0 +1,71 @@
+# GameShark Compatibility
+
+GameShark Compatibility brings a GameShark-style cheat and debug menu to Gen1Recomp.
+
+It supports the Gen 1 and Gen 2 games supported by Gen1Recomp, including Pokémon Red, Blue, Yellow, Gold, Silver, and Crystal where supported by the current engine.
+
+## Features
+
+GameShark includes a growing collection of cheat and debug tools, including:
+
+- Walk Through Walls
+- No Random Battles
+- Infinite HP
+- Infinite PP
+- One Hit KO
+- Burn Foe
+- Max Money
+- Max Game Corner Coins
+- Master Balls
+- Rare Candies
+- Badge cheats
+- Safari Zone cheats
+- Steal / Catch Trainer Pokémon
+- Wild Pokémon selector
+- Wild Pokémon level selection
+- Gen 2 gender and shiny controls
+- Instant wild battles
+- Teleport
+- Give Item with selectable quantities
+- Unrestricted Teach Move
+- DV / EV (Stat EXP) editor
+
+## Wild Pokémon tools
+
+Choose the species you want to encounter and optionally override its level.
+
+Gen 2 also supports gender and shiny controls.
+
+The Instant Battle option starts a battle immediately with the selected Pokémon instead of waiting for a normal wild encounter.
+
+## Teleport
+
+Teleport to major game destinations without requiring the normal Fly restrictions.
+
+## Give Item
+
+Choose an item from the active game's own item list and add a selected quantity directly to the player's inventory.
+
+## Teach Move
+
+Choose a Pokémon from your party and teach it any move available in the current game.
+
+Normal species, TM, HM, and learnset restrictions are intentionally bypassed.
+
+If the Pokémon already knows four moves, GameShark lets you choose which move slot to replace.
+
+## DV / EV Editor
+
+Edit Pokémon DVs and the original Gen 1 / Gen 2 Stat EXP values directly.
+
+The editor recalculates the Pokémon's resulting stats after changes.
+
+## Compatibility
+
+GameShark is designed as a standalone mod and does not require another cheat, move-management, or DV/EV mod.
+
+It uses Gen1Recomp Mod API 2 and supports Gen 1 and Gen 2 through generation-aware code paths.
+
+Source and releases are maintained at:
+
+`goofwear/gameshark`

--- a/mods/goofwear@GameShark/meta.json
+++ b/mods/goofwear@GameShark/meta.json
@@ -1,0 +1,32 @@
+{
+  "id": "GameShark",
+  "title": "GameShark Compatibility",
+  "author": "goofwear",
+  "summary": "A GameShark-style cheat and debug menu with battle cheats, wild Pokemon controls, teleporting, item and move tools, DV/EV editing, and more.",
+  "version": "0.7.7",
+  "categories": [
+    "TOOL",
+    "GAMEPLAY",
+    "QOL"
+  ],
+  "tags": [
+    "gameshark",
+    "cheats",
+    "debug",
+    "pokemon",
+    "gen 1",
+    "gen 2"
+  ],
+  "repo": "https://github.com/goofwear/gameshark",
+  "github": "goofwear/gameshark",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.79 || =0.0.0-dev",
+  "games": [
+    "gen1",
+    "gen2"
+  ],
+  "profile": "overhaul",
+  "dependencies": [],
+  "conflicts": []
+}


### PR DESCRIPTION
Adds GameShark Compatibility to the Gen1Recomp mod index.

Source:
https://github.com/goofwear/gameshark

Features include GameShark-style battle cheats, Wild Pokémon controls, Instant Battle, Teleport, Give Item, unrestricted Teach Move, and DV/EV editing.

Supported generations:
- Gen 1
- Gen 2

Validation completed locally using the mod-index validation tools and Gen1Recomp modkit checks.

Mod or cart:
- [x] Mod

Checklist:
- [x] `modkit.py validate GameShark --strict` passes
- [x] `modkit.py lint GameShark` passes
- [x] the distributed `.zip` contains the mod files in the expected install layout
- [x] nothing distributed is ROM-derived
- [x] `meta.json` matches the mod's `manifest.json`
- [x] this PR only touches `mods/goofwear@GameShark/`