### PR TITLE
Add Solo Run Modpack 2.0.2

### DIFF
--- a/mods/GymLeaderMatt@solo_run_modpack/description.md
+++ b/mods/GymLeaderMatt@solo_run_modpack/description.md
@@ -1,0 +1,3 @@
+A collection that aims to give a true 'solo run' experience. It has options to change your starter, give them perfect DVs, eliminate the need for HM users or guarantee their spawns/catch rate of Pokeballs. It also lets you auto use field moves with no input, adds a select menu to fly/dig/use the bike, allows a Brock skip, enforces no items in bttle, adds the badge boost glitch, a toggle for early encounters, instant text, wait sounds, poison flash in the overworld, lights up Rock Tunnel, and auto solves the Lt. Surge trash can puzzle.
+
+Lots of things that I run for my ruleset for videos I make as a hobby. This puts them all in one place to share with anyone who wants to get into the hobby.

--- a/mods/GymLeaderMatt@solo_run_modpack/meta.json
+++ b/mods/GymLeaderMatt@solo_run_modpack/meta.json
@@ -1,0 +1,28 @@
+{
+  "id": "solo_run_modpack",
+  "title": "Solo Run Modpack",
+  "author": "Gym Leader Matt",
+  "version": "2.0.2",
+  "categories": [
+    "GAMEPLAY",
+    "BALANCE",
+    "QOL"
+  ],
+  "repo": "https://github.com/GymLeaderMatt/Solo_Run_Modpack_Gen1_Recomp",
+  "summary": "A collection for the solo run experience.",
+  "tags": [
+    "solo run",
+    "starter change",
+    "gym leader matt"
+  ],
+  "github": "GymLeaderMatt/Solo_Run_Modpack_Gen1_Recomp",
+  "conflicts": [
+    "quality_of_life",
+    "jj_auto_field_moves"
+  ],
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/GymLeaderMatt@solo_run_modpack/` — **Solo Run Modpack** 2.0.2 by Gym Leader Matt.

- Source: https://github.com/GymLeaderMatt/Solo_Run_Modpack_Gen1_Recomp
- Releases tracked from: `GymLeaderMatt/Solo_Run_Modpack_Gen1_Recomp`
- Categories: GAMEPLAY, BALANCE, QOL
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>