### PR TITLE
Add Gen2 Tradução pt-br  crystal

### DIFF
--- a/mods/LordSangreal@versaocristal/description.md
+++ b/mods/LordSangreal@versaocristal/description.md
@@ -1,0 +1,46 @@
+# Versao Cristal
+
+**Pokemon Crystal em portugues brasileiro.** Tradução própria, escrita diretamente a partir do inglês original de cada fala da ROM de Crystal.
+
+Roda em dois motores a partir do mesmo pacote: `gen1recomp` e [Gen2Recomped](https://github.com/UNDERdecoded/Gen2Recomped), com suporte completo a PC e Android.
+
+Nao acompanha nenhum byte de ROM. **Todo o texto e traducao propria, escrita do zero a partir do ingles da ROM de Crystal** -- nao ha uma linha derivada de outra traducao no pacote.
+
+## Cobertura e Compatibilidade
+
+| Categoria | Estado |
+|---|---|
+| Falas e diálogos de NPC | 11.519 entradas com registro duplo (ponteiros de ROM e rótulos) |
+| Menus e batalha | 1.095 chaves sincronizadas |
+| Pontos de referência no mapa (`landmarks.lua`) | 94 locais de Johto e Kanto formatados em 11 colunas ou menos |
+| Descrições de golpe | 251 descrições completas |
+| Descrições de item | 161 descrições completas |
+| Glifos acentuados desenhados | 25 caracteres em página própria de fonte |
+
+O mod conta com **registro duplo de ponteiros**: o motor `gen1recomp` busca as falas por ponteiro de banco (`banco:endereco`), enquanto o `Gen2Recomped` indexa por rótulo (`TEXT_S...` / rótulo nomeado). O pacote registra ambos simultaneamente, garantindo compatibilidade transparente em qualquer um dos dois ambientes.
+
+## O que você pode escolher
+
+No menu **MODS -> Versao Cristal -> OPTIONS**, é possível personalizar independentemente:
+
+- **FALAS:** PORTUGUÊS / ENGLISH
+- **MENUS E BATALHA:** PORTUGUÊS / ENGLISH
+- **DESCRIÇÕES DE GOLPES:** PORTUGUÊS / ENGLISH
+- **DESCRIÇÕES DE ITENS:** PORTUGUÊS / ENGLISH
+
+O padrão é 100% em português, e a alteração tem efeito no próximo boot do jogo.
+
+## O que fica no original, de propósito
+
+- **Nomes de POKéMON** (BULBASAUR, SUICUNE, CELEBI), **nomes de personagens** (EUSINE, CLAIR, PROF. ELM) e siglas **TM/HM** permanecem no original para preservar a comunicação universal e o padrão oficial da franquia.
+- **Nomes de golpes e itens** permanecem no padrão da franquia, com todas as descrições explicativas traduzidas em português brasileiro (com base no TCG oficial).
+- **Cidade, Rota e Vila traduzem a palavra genérica**, preservando o nome próprio ("VIOLET CITY" -> "CIDADE DE VIOLET", "ROUTE 30" -> "ROTA 30").
+- **A interface do launcher e gerenciador de mods** permanece em inglês devido ao tamanho fixo dos botões do aplicativo.
+
+## Acentuação
+
+O mod acrescenta uma **página própria de 25 glifos acentuados** (`assets/font/latin.png`) acima das páginas da ROM, sem sobrescrever caracteres existentes. Cada caractere acentuado ocupa exatamente uma coluna de texto.
+
+## Joga Gold ou Silver?
+
+A tradução para Pokémon Gold e Silver está disponível no mod [Versao Dourada](https://github.com/LordSangreal/versaodourada).

--- a/mods/LordSangreal@versaocristal/meta.json
+++ b/mods/LordSangreal@versaocristal/meta.json
@@ -1,0 +1,31 @@
+{
+  "id": "versaocristal",
+  "title": "Gen2 Tradução pt-br  crystal",
+  "author": "LordSangreal",
+  "summary": "Pokémon Crystal em português brasileiro. Tradução própria, escrita do inglês original de cada fala, com registro duplo de ponteiros e compatibilidade total com o gen1recomp.",
+  "version": "0.47.1",
+  "categories": [
+    "TRANSLATION"
+  ],
+  "tags": [
+    "portugues",
+    "brasileiro",
+    "portuguese",
+    "brazilian",
+    "traducao",
+    "crystal",
+    "gen2"
+  ],
+  "repo": "https://github.com/LordSangreal/versaocristal-ptbr",
+  "github": "LordSangreal/versaocristal-ptbr",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.0.0-0 <2.0.0",
+  "games": [
+    "gen2"
+  ],
+  "profile": "content",
+  "permissions": [],
+  "dependencies": [],
+  "conflicts": []
+}


### PR DESCRIPTION
**Mod:** Gen2 Tradução pt-br  crystal — by LordSangreal
**Folder:** `mods/LordSangreal@versaocristal/`
**Source:** https://github.com/LordSangreal/versaocristal-ptbr

- [x] `scripts/validate.mjs`, `scripts/check-links.mjs`, and `scripts/scan-lua.mjs` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/<Author>@<id>/`

---

Brazilian Portuguese translation for Pokémon **Crystal**. Every single line of NPC dialogue, interaction, map landmark, and game string is translated directly from the original English of the Crystal ROM.

### Features and Compatibility
- **Dual pointer registration**: registers both direct ROM pointers (`bank:address` for `gen1recomp`) and named labels (`TEXT_S...` for `Gen2Recomped`), ensuring seamless compatibility across both engine platforms on PC and Android.
- **Accented typography**: includes custom drawn Latin accented glyph page (`assets/font/latin.png`) without overwriting ROM font bytes.
- **Independent options**: player can independently toggle language options under MODS menu (NPC speech, battle & menus, move descriptions, item descriptions).
- **Zero ROM bytes shipped**: 100% original translation texts and own font assets.

### Notes on the checks
- `scan-lua.mjs` reports 6 "a human should read" review lines due to substring matching on `requires_restart = true` in `main.lua` and the English word `required.` in `lang/strings.lua`. No runtime sandbox escapes or network/filesystem calls exist.
- `categories` is `TRANSLATION` and `games` is `["gen2"]` (matching schema enum vocabulary).
