### PR TITLE
Add campavao@battle_royale (Kanto Battle Royale)

### DIFF
--- a/mods/campavao@battle_royale/description.md
+++ b/mods/campavao@battle_royale/description.md
@@ -1,0 +1,43 @@
+# Kanto Battle Royale
+
+Last trainer standing, played across the whole of Kanto. Up to eight players
+share a lobby, and the rest of the field is filled with bots so a match always
+starts.
+
+## How a match runs
+
+Everyone begins in the **SAFARI ZONE** with 30 SAFARI BALLs and two minutes.
+There is no starter — whatever you catch is your team, and if the buzzer goes
+with an empty party you are out before the match proper begins.
+
+When the PA calls time you walk to the gate and pick the town you drop into.
+From there it is Kanto as you know it: gyms, shops, the Pokémon Center, wild
+grass. Walk into another trainer's line of sight and the battle starts on its
+own — no menu, no consent. A whiteout puts you out for good, and your bag
+spills onto the ground where you fell for whoever gets there first.
+
+Then the fog closes. It sweeps in on the Town Map toward a shrinking ring,
+taking maps out of play as it goes, until the survivors are pushed into the
+same few routes and one trainer is left.
+
+## Playing it
+
+**SOLO VS BOTS** needs nothing but the mod. Multiplayer runs over a small relay
+server; the default points at a hosted one, so a room code is all you and your
+friends need. You can point it at your own relay instead — the server is in
+`relay/`, it is about 500 lines of Node, and it stores nothing.
+
+Everyone in a match needs the same engine release and the same mod version. The
+link handshake compares them exactly and refuses a mismatch, which is a real
+constraint rather than a suggestion — [COMPATIBILITY.md](https://github.com/campavao/kanto-battle-royale/blob/main/COMPATIBILITY.md)
+explains what has to line up and why.
+
+## Installing
+
+Import `battle_royale-<version>.zip` from the in-game Mod Manager
+(MODS > Import mod .zip), enable it, and grant the network permission when
+asked. Updates are offered in-game from then on.
+
+Full details, options and the changelog:
+[README](https://github.com/campavao/kanto-battle-royale#readme) and
+[releases](https://github.com/campavao/kanto-battle-royale/releases).

--- a/mods/campavao@battle_royale/meta.json
+++ b/mods/campavao@battle_royale/meta.json
@@ -1,0 +1,35 @@
+{
+  "id": "battle_royale",
+  "title": "Kanto Battle Royale",
+  "author": "campavao",
+  "summary": "Last trainer standing in Kanto. Catch a team in the SAFARI ZONE, drop into a town, and fight everyone else as the fog closes in.",
+  "version": "0.36.0",
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT"
+  ],
+  "tags": [
+    "multiplayer",
+    "battle royale",
+    "pvp",
+    "ruleset",
+    "hardcore"
+  ],
+  "repo": "https://github.com/campavao/kanto-battle-royale",
+  "github": "campavao/kanto-battle-royale",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.2.26 <2.0.0",
+  "games": [
+    "gen1"
+  ],
+  "profile": "content",
+  "affects_link": true,
+  "permissions": [
+    "network",
+    "engine_internals"
+  ],
+  "dependencies": [],
+  "conflicts": [],
+  "license": "MIT"
+}


### PR DESCRIPTION
**Mod or cart:** Kanto Battle Royale 0.36.0, by campavao
**Folder:** `mods/campavao@battle_royale/`
**Source:** https://github.com/campavao/kanto-battle-royale

- [x] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/<Author>@<id>/`

A battle royale for Kanto: everyone catches a team in the SAFARI ZONE against
a clock, picks a town to drop into, and fights until one trainer is left as a
fog ring closes over the Town Map. Solo against bots needs nothing but the mod;
multiplayer runs over a small relay server, and you can point it at your own.

Two things were fixed in 0.36.0 specifically to meet the checklist above, in
case it saves a reviewer the diff:

- The release zip no longer carries the mod's `tests/` directory. It was 39% of
  the download and nothing at runtime read it. Files now sit at the archive
  root rather than under `battle_royale/`.
- The manifest now declares `engine_internals`. The mod has always required
  private engine modules; only the declaration is new.

`meta.json` maps the manifest's `MULTIPLAYER` category onto `GAMEPLAY` +
`CONTENT`, since `MULTIPLAYER` isn't in the index enum.
