### PR TITLE
Add Trainer Skins Mod

### DIFF
--- a/mods/DarkwarePX@trainer_skins/description.md
+++ b/mods/DarkwarePX@trainer_skins/description.md
@@ -1,0 +1,7 @@
+Trainer Skins adds customizable trainer sprites to Pokémon Gen 1 and Gen 2 in Gen 1 Recomp.
+
+Features include custom trainer sprites for battles, overworld movement, biking, surfing, Surfing Pikachu, fishing, Trainer Card and Hall of Fame.
+
+The mod includes an in-game skin selector with battle and overworld previews and selectable Red, Green and Blue base palettes.
+
+Missing sprite files automatically fall back to the game's default trainer graphics.

--- a/mods/DarkwarePX@trainer_skins/meta.json
+++ b/mods/DarkwarePX@trainer_skins/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "trainer_skins",
+  "title": "Trainer Skins",
+  "author": "DarkwarePX",
+  "version": "0.1.0",
+  "categories": [
+    "ART",
+    "UI"
+  ],
+  "repo": "https://github.com/DarkwarePX/Trainer-Skins",
+  "github": "DarkwarePX/Trainer-Skins",
+  "game_version": ">=0.2.24",
+  "permissions": [
+    "engine_internals"
+  ],
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
<!-- The submission helper fills this in for you: https://bryanthaboi.github.io/gen1recomp-mod-index/ -->

**Mod or cart:** Trainer Skins v0.1.0 by DarkwarePX
**Folder:** `mods/DarkwarePX@trainer_skins/`
**Source:** https://github.com/DarkwarePX/Trainer-Skins

- [ ] `modkit.py validate <id> --strict` and `modkit.py lint <id>` pass
- [x] the distributed `.zip` has the mod's files at the archive root
- [x] nothing distributed is ROM-derived (no extracted art, chip banks, ROMs or patches)
- [x] `meta.json` matches the mod's `manifest.json` (id, api, profile, permissions, dependencies, conflicts)
- [x] this PR only touches `mods/<Author>@<id>/`

Carts only:

- [ ] `meta.json` matches the bundle's `cart.json` (base, seal, mods, load_order)
- [ ] the bundle contains no `.lua`
- [ ] every pinned build is public and every mod author is credited

<!-- Version bumps do not need a PR: entries with "github" and
     automatic_version_check are re-read from your Releases nightly. -->
