### PR TITLE
Add seven Mister Miracle mods, update snag_quest

### DIFF
--- a/mods/MisterMiracle@expanded_species/description.md
+++ b/mods/MisterMiracle@expanded_species/description.md
@@ -1,0 +1,18 @@
+Expanded Species is a framework for Gold/Silver/Crystal that lets
+species packs register custom Pokémon above the original 251. On its
+own it adds nothing — it is the foundation species packs are built on.
+
+**What it gives pack authors:**
+- Custom species with their own sprites, icons, cries, palettes and
+  Pokédex entries
+- Wild encounters that add to a route rather than replacing it — grass,
+  surfing, all three fishing rods, swarms, and the Bug-Catching Contest
+- Custom Pokémon placed into existing trainers without disturbing their
+  NPC, dialogue, defeated flag, or rewards
+- Gifts, stationary encounters, custom trainers and NPC trades
+- Per-individual named forms that survive evolution, trading, egg
+  hatching and save/reload
+- A **Save Guardian**: if a species pack is removed, its Pokémon are
+  quarantined intact and restored when the pack comes back
+
+Requires gen1recomp 0.1.94 or newer. Licensed MIT.

--- a/mods/MisterMiracle@expanded_species/meta.json
+++ b/mods/MisterMiracle@expanded_species/meta.json
@@ -2,10 +2,18 @@
   "id": "expanded_species",
   "title": "Expanded Species",
   "author": "Mister Miracle",
-  "summary": "A framework for custom species above #255 on Gold/Silver/Crystal. It adds no Pokemon itself - species packs built on it do. Uncapped encounters, trainer helpers, cosmetic forms and missing-pack save protection.",
+  "summary": "A framework for custom species above #255 on Gold/Silver/Crystal. It adds no Pokemon itself - species packs do. Uncapped encounters, trainer helpers, cosmetic forms and save protection.",
   "version": "0.6.6",
-  "categories": ["LIBRARY", "CONTENT"],
-  "tags": ["framework", "modding-tool", "custom species", "gen2"],
+  "categories": [
+    "LIBRARY",
+    "CONTENT"
+  ],
+  "tags": [
+    "framework",
+    "modding-tool",
+    "custom species",
+    "gen2"
+  ],
   "repo": "https://github.com/mistermiracle3036/Expanded-Species",
   "github": "mistermiracle3036/Expanded-Species",
   "automatic_version_check": true,
@@ -14,7 +22,9 @@
   "game_version": ">=0.1.94 <2.0.0",
   "profile": "content",
   "affects_link": false,
-  "permissions": ["engine_internals"],
+  "permissions": [
+    "engine_internals"
+  ],
   "dependencies": [],
   "conflicts": []
 }

--- a/mods/MisterMiracle@expanded_species/meta.json
+++ b/mods/MisterMiracle@expanded_species/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "expanded_species",
+  "title": "Expanded Species",
+  "author": "Mister Miracle",
+  "summary": "A framework for custom species above #255 on Gold/Silver/Crystal. It adds no Pokemon itself - species packs built on it do. Uncapped encounters, trainer helpers, cosmetic forms and missing-pack save protection.",
+  "version": "0.6.6",
+  "categories": ["LIBRARY", "CONTENT"],
+  "tags": ["framework", "modding-tool", "custom species", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Expanded-Species",
+  "github": "mistermiracle3036/Expanded-Species",
+  "automatic_version_check": true,
+  "license": "MIT",
+  "api": 2,
+  "game_version": ">=0.1.94 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@gold_records/description.md
+++ b/mods/MisterMiracle@gold_records/description.md
@@ -1,0 +1,8 @@
+Gold Records is a quest mod for Gold/Silver/Crystal. **Alpha —
+playable but unfinished.**
+
+Roxie came to Johto chasing a music scene. What she found was temple
+bells, a sleeping Wooper, and enough spite to start a band anyway.
+You are her manager — recruit musicians, book gigs, and deal with
+whatever Johto throws at a punk rocker who will not take no for an
+answer.

--- a/mods/MisterMiracle@gold_records/meta.json
+++ b/mods/MisterMiracle@gold_records/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "gold_records",
+  "title": "Gold Records (Alpha)",
+  "author": "Mister Miracle",
+  "summary": "ALPHA - Roxie came to Johto for a music scene, found temple bells and a sleeping Wooper, and is starting a band out of spite. You are her manager. Gold/Silver/Crystal.",
+  "version": "0.4.2",
+  "categories": ["CONTENT", "GAMEPLAY"],
+  "tags": ["quest", "music", "johto", "gen2", "alpha"],
+  "repo": "https://github.com/mistermiracle3036/Gold-Records",
+  "github": "mistermiracle3036/Gold-Records",
+  "automatic_version_check": true,
+  "license": "MIT",
+  "api": 2,
+  "game_version": ">=0.1.78 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@indigo_conference/description.md
+++ b/mods/MisterMiracle@indigo_conference/description.md
@@ -1,0 +1,10 @@
+Indigo Plateau Conference adds a repeatable tournament circuit to
+Gold/Silver/Crystal. Five Pokémon Centers across Johto host four rounds
+of guest challengers in their unused upstairs rooms, badge-gated from
+the first gym through to the Indigo Plateau final.
+
+**Features**
+- Repeatable battles with guest trainers you will not find elsewhere
+- Five tournament venues across Johto, each unlocked by a badge
+- Final tournament at the Indigo Plateau
+- Works on Gold, Silver, and Crystal

--- a/mods/MisterMiracle@indigo_conference/meta.json
+++ b/mods/MisterMiracle@indigo_conference/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "indigo_conference",
+  "title": "Indigo Plateau Conference",
+  "author": "Mister Miracle",
+  "summary": "A repeatable tournament circuit for Gold/Silver/Crystal. Four rounds of guest challengers in the unused upstairs room of five Pokemon Centers, badge-gated, ending at the Indigo Plateau.",
+  "version": "1.0.2",
+  "categories": ["CONTENT", "GAMEPLAY"],
+  "tags": ["tournament", "battles", "johto", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Indigo-Plateau-Conference",
+  "github": "mistermiracle3036/Indigo-Plateau-Conference",
+  "automatic_version_check": true,
+  "license": "MIT",
+  "api": 2,
+  "game_version": ">=0.1.78 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@kanto_balls/description.md
+++ b/mods/MisterMiracle@kanto_balls/description.md
@@ -1,0 +1,17 @@
+Too Many Balls adds twenty custom Poké Balls to gen1recomp, across both
+Gen 1 (Red/Blue/Yellow) and Gen 2 (Gold/Silver/Crystal).
+
+**Canon balls** — Quick, Timer, Net, Dusk, Repeat, Dream, Dive, and
+Luxury join the mart shelves with shop descriptions that tell you what
+each one does before you buy. Cherish Ball is a one-time gift from Kurt.
+
+**Quest balls** — Cage, Crystal, Strange, and Origin are handed out by
+stories and never sold in normal play.
+
+**Kurt and the Ball Case** — Return to Kurt after the Slowpoke Well and
+he hands over the Ball Case, plus a Cherish Ball. Use it from your pack
+to mix Apricorns into five balls of its own (Kecleon, Drift, Snare,
+Catalyst, Cradle) and to stow the whole collection out of your pack.
+Nothing is ever lost.
+
+Works alongside Custom Poké Balls and Pokeball Colors (both optional).

--- a/mods/MisterMiracle@kanto_balls/meta.json
+++ b/mods/MisterMiracle@kanto_balls/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "kanto_balls",
+  "title": "Too Many Balls",
+  "author": "Mister Miracle",
+  "summary": "Custom Poke Balls for Red/Blue/Yellow and Gold/Silver/Crystal. Twenty new balls including canon favorites, quest-only balls, and an Apricorn workbench with a Ball Case from Kurt.",
+  "version": "0.8.7",
+  "categories": ["CONTENT", "GAMEPLAY"],
+  "tags": ["pokeballs", "catching", "items", "gen1", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Too-Many-Balls",
+  "github": "mistermiracle3036/Too-Many-Balls",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.38 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@kanto_contests/description.md
+++ b/mods/MisterMiracle@kanto_contests/description.md
@@ -1,0 +1,13 @@
+Kanto Contests brings Ruby/Sapphire-style Pokémon Contests to
+gen1recomp. **Alpha — playable but unfinished.**
+
+Raise your Pokémon's condition with PokéSnacks, earn and wear contest
+scarves, then enter one of five contests — COOL, BEAUTY, CUTE, SMART,
+or TOUGH — and appeal with your Pokémon's moves scored by contest
+category rather than damage. Available in Kanto and Johto.
+
+Wins are recorded per category on the Pokémon, so Ribbons awards the
+matching ribbon automatically if installed. Coordinators and contest
+ranks are still to come.
+
+Works on Red/Blue/Yellow and Gold/Silver/Crystal.

--- a/mods/MisterMiracle@kanto_contests/meta.json
+++ b/mods/MisterMiracle@kanto_contests/meta.json
@@ -2,10 +2,19 @@
   "id": "kanto_contests",
   "title": "Kanto Contests (Alpha)",
   "author": "Mister Miracle",
-  "summary": "ALPHA - Ruby/Sapphire-style Pokemon Contests in Kanto and Johto. Raise condition with PokeSnacks, earn contest scarves, then appeal in COOL, BEAUTY, CUTE, SMART or TOUGH. Wins are recorded per category on the Pokemon.",
+  "summary": "ALPHA - Ruby/Sapphire-style Pokemon Contests in Kanto and Johto. Raise condition with PokeSnacks, earn scarves, then appeal in COOL, BEAUTY, CUTE, SMART or TOUGH. Wins record per category.",
   "version": "0.15.0",
-  "categories": ["CONTENT", "GAMEPLAY"],
-  "tags": ["contests", "celadon", "alpha", "gen1", "gen2"],
+  "categories": [
+    "CONTENT",
+    "GAMEPLAY"
+  ],
+  "tags": [
+    "contests",
+    "celadon",
+    "alpha",
+    "gen1",
+    "gen2"
+  ],
   "repo": "https://github.com/mistermiracle3036/Kanto-Contests",
   "github": "mistermiracle3036/Kanto-Contests",
   "automatic_version_check": true,
@@ -13,7 +22,9 @@
   "game_version": ">=0.1.75 <2.0.0",
   "profile": "content",
   "affects_link": false,
-  "permissions": ["engine_internals"],
+  "permissions": [
+    "engine_internals"
+  ],
   "dependencies": [],
   "conflicts": []
 }

--- a/mods/MisterMiracle@kanto_contests/meta.json
+++ b/mods/MisterMiracle@kanto_contests/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "kanto_contests",
+  "title": "Kanto Contests (Alpha)",
+  "author": "Mister Miracle",
+  "summary": "ALPHA - Ruby/Sapphire-style Pokemon Contests in Kanto and Johto. Raise condition with PokeSnacks, earn contest scarves, then appeal in COOL, BEAUTY, CUTE, SMART or TOUGH. Wins are recorded per category on the Pokemon.",
+  "version": "0.15.0",
+  "categories": ["CONTENT", "GAMEPLAY"],
+  "tags": ["contests", "celadon", "alpha", "gen1", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Kanto-Contests",
+  "github": "mistermiracle3036/Kanto-Contests",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.75 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@kanto_ribbons/description.md
+++ b/mods/MisterMiracle@kanto_ribbons/description.md
@@ -1,0 +1,10 @@
+Ribbons adds nineteen per-Pokémon ribbons to gen1recomp, awarded
+automatically and shown inside the status screen. Works on both Gen 1
+(Red/Blue/Yellow) and Gen 2 (Gold/Silver/Crystal).
+
+Ribbons are earned through play — beating certain trainers, catching
+milestones, bond events — bought from a vendor, or bonded through
+loyalty. Awards apply retroactively where the save allows.
+
+Integrates with Kanto Contests (contest win ribbons), Pokemon Snag
+(snag ribbons), and happiness mods (bond ribbons). All optional.

--- a/mods/MisterMiracle@kanto_ribbons/meta.json
+++ b/mods/MisterMiracle@kanto_ribbons/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "kanto_ribbons",
+  "title": "Ribbons",
+  "author": "Mister Miracle",
+  "summary": "Nineteen per-Pokemon ribbons for Red/Blue/Yellow and Gold/Silver/Crystal - earned, bought, and bonded - awarded automatically and shown inside the status screen.",
+  "version": "0.22.1",
+  "categories": ["GAMEPLAY", "UI"],
+  "tags": ["ribbons", "collection", "status screen", "gen1", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Ribbons",
+  "github": "mistermiracle3036/Ribbons",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.38 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@pokeball_colors/description.md
+++ b/mods/MisterMiracle@pokeball_colors/description.md
@@ -1,0 +1,16 @@
+Pokeball Colors gives every Poké Ball its own throw, preview, and
+heal-machine palette on both Gen 1 and Gen 2. It works with vanilla
+balls and any ball added by other mods (Too Many Balls, Custom Poké
+Balls, etc.).
+
+A **BALL COLORS** menu on the PC lets you pick presets or set body,
+accent, and third colour by hand with full 0–255 control. The preview
+shows the real ball sprite in your colours, so what you choose is what
+you see when you throw. Your colours save with your game.
+
+**Features**
+- Per-ball throw palette for every ball in the game
+- PC colour editor with per-ball presets and manual RGB
+- Heal-machine ball colours on Gen 2
+- Auto-detects balls from other mods
+- Works on Red/Blue/Yellow and Gold/Silver/Crystal

--- a/mods/MisterMiracle@pokeball_colors/meta.json
+++ b/mods/MisterMiracle@pokeball_colors/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "pokeball_colors",
+  "title": "Pokeball Colors",
+  "author": "Mister Miracle",
+  "summary": "Per-ball throw, preview and heal-machine colors for Red/Blue/Yellow and Gold/Silver/Crystal. Includes a color editor on the PC where you design your own ball palettes.",
+  "version": "0.1.64",
+  "categories": ["ART", "UI"],
+  "tags": ["cosmetic", "battle", "pokeballs", "color editor", "gen1", "gen2"],
+  "repo": "https://github.com/mistermiracle3036/Pokeball-Colors",
+  "github": "mistermiracle3036/Pokeball-Colors",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.1.38 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
+}

--- a/mods/MisterMiracle@snag_quest/description.md
+++ b/mods/MisterMiracle@snag_quest/description.md
@@ -1,19 +1,20 @@
-Snag Quest adds a Team Rocket questline to gen1recomp. Jessie recruits
-you in Viridian City with a custom **Snag Ball** that steals Pokémon
-straight out of trainer battles — starting with a guaranteed shiny
-Meowth from a picnicker who isn't what she seems.
+Pokemon Snag adds a theft mechanic to gen1recomp. A custom **Snag Ball**
+lets you steal Pokémon straight out of trainer battles — on Red/Blue/Yellow,
+Jessie recruits you at Nugget Bridge with a guaranteed shiny Meowth as the
+questline reward. On Gold/Silver/Crystal, a sailor in Cherrygrove City
+starts you off, with contract brokers in Goldenrod and Ecruteak.
 
-Beyond the intro quest, a network of black-market "fences" scattered
-around Kanto will buy snagged Pokémon off you for more Snag Balls,
-paying more for high-level, hard-to-catch, or VIP-owned mons (your
-rival, gym leaders, the Elite Four).
+Black-market fences scattered across Kanto and Johto buy snagged Pokémon
+for more Snag Balls, paying more for high-level, hard-to-catch, or
+VIP-owned mons (your rival, gym leaders, the Elite Four).
 
 **Features**
-- Guaranteed shiny snag as the questline reward
 - Trainer-battle-only custom ball with permanent snag marking
+- Guaranteed shiny snag as the questline reward
 - Optional: battles continue after a snag instead of ending
 - Optional: Snag Balls purchasable in marts
-- Fences at Celadon Game Corner and Pewter City (Boulder Badge gated)
+- Fences across Kanto and Johto, badge-gated
+- Works on Gen 1 (Red/Blue/Yellow) and Gen 2 (Gold/Silver/Crystal)
 
-Compatible with Quest System (required), kanto_ribbons, SHINY_POKEMON
-(optional), and voxel mode.
+Compatible with pokeball_colors, kanto_ribbons, kanto_balls, and
+SHINY_POKEMON (all optional).

--- a/mods/MisterMiracle@snag_quest/meta.json
+++ b/mods/MisterMiracle@snag_quest/meta.json
@@ -2,28 +2,18 @@
   "id": "snag_quest",
   "title": "Pokemon Snag",
   "author": "Mister Miracle",
-  "version": "0.12.0",
-  "categories": [
-    "GAMEPLAY",
-    "CONTENT"
-  ],
+  "summary": "Steal Pokemon from other trainers with the SNAG BALL. On Red, earn it through Jessie's questline at Nugget Bridge. On Gold, a sailor in Cherrygrove starts you off with contracts across Johto. Fence what you take to black-market buyers.",
+  "version": "0.15.9",
+  "categories": ["GAMEPLAY", "CONTENT"],
+  "tags": ["quest", "catching", "team rocket", "gen1", "gen2"],
   "repo": "https://github.com/mistermiracle3036/Pokemon-Snag",
-  "summary": "Steal Pokemon from other trainers with the SNAG BALL, and fence what you steal for more balls.",
-  "tags": [
-    "theft",
-    "snag",
-    "trainer-battles",
-    "questline",
-    "team-rocket"
-  ],
   "github": "mistermiracle3036/Pokemon-Snag",
-  "game_version": ">=0.1.38",
-  "dependencies": [
-    "quest_system"
-  ],
-  "permissions": [
-    "engine_internals"
-  ],
+  "automatic_version_check": true,
   "api": 2,
-  "profile": "content"
+  "game_version": ">=0.1.38 <2.0.0",
+  "profile": "content",
+  "affects_link": false,
+  "permissions": ["engine_internals"],
+  "dependencies": [],
+  "conflicts": []
 }

--- a/mods/MisterMiracle@snag_quest/meta.json
+++ b/mods/MisterMiracle@snag_quest/meta.json
@@ -2,10 +2,19 @@
   "id": "snag_quest",
   "title": "Pokemon Snag",
   "author": "Mister Miracle",
-  "summary": "Steal Pokemon from other trainers with the SNAG BALL. On Red, earn it through Jessie's questline at Nugget Bridge. On Gold, a sailor in Cherrygrove starts you off with contracts across Johto. Fence what you take to black-market buyers.",
+  "summary": "Steal Pokemon from other trainers with the SNAG BALL. Earn it from Jessie at Nugget Bridge on Red, or a Cherrygrove sailor on Gold, then fence what you take to black-market buyers.",
   "version": "0.15.9",
-  "categories": ["GAMEPLAY", "CONTENT"],
-  "tags": ["quest", "catching", "team rocket", "gen1", "gen2"],
+  "categories": [
+    "GAMEPLAY",
+    "CONTENT"
+  ],
+  "tags": [
+    "quest",
+    "catching",
+    "team rocket",
+    "gen1",
+    "gen2"
+  ],
   "repo": "https://github.com/mistermiracle3036/Pokemon-Snag",
   "github": "mistermiracle3036/Pokemon-Snag",
   "automatic_version_check": true,
@@ -13,7 +22,9 @@
   "game_version": ">=0.1.38 <2.0.0",
   "profile": "content",
   "affects_link": false,
-  "permissions": ["engine_internals"],
+  "permissions": [
+    "engine_internals"
+  ],
   "dependencies": [],
   "conflicts": []
 }


### PR DESCRIPTION
## Summary

- **Seven new mods:** pokeball_colors, kanto_balls (Too Many Balls), kanto_ribbons, kanto_contests, expanded_species, indigo_conference, gold_records
- **Updated:** snag_quest — new summary covering Gen 2 questline, dropped quest_system hard dependency (now optional), bumped version to 0.15.9
- All eight entries have current descriptions, `automatic_version_check: true`, and match their repos

Supersedes the earlier `add-mistermiracle-mods` branch (which included shop_events, example_balls, and npc_inspector — those are removed from this submission).