### PR TITLE
PokéGear Menu: declare gen2

### DIFF
--- a/mods/Code-Grub@pokegear_menu/meta.json
+++ b/mods/Code-Grub@pokegear_menu/meta.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "summary": "The START menu restyled as a handheld: nine apps in a 3x3 grid over the overworld. A reskin of the menu, not the Gen 2 device.",
   "games": [
-    "gen1"
+    "gen1",
+    "gen2"
   ]
 }


### PR DESCRIPTION
0.2.0 runs on Gold, Silver and Crystal, so the entry should declare `gen2`.

I left `version` at 0.1.8 rather than bumping it, since the nightly job picks
that up. v0.2.0 is tagged and released. `node scripts/validate.mjs
mods/Code-Grub@pokegear_menu` passes with 0 warnings.
