### PR TITLE
Add TM/HM Move Names 1.1.0

### DIFF
--- a/mods/Tonedawg1@tm_hm_names/description.md
+++ b/mods/Tonedawg1@tm_hm_names/description.md
@@ -1,0 +1,1 @@
+Shows the move names next to TM/HM numbers (Gen 2 style) in Pokémon Red, Blue, and Yellow.

--- a/mods/Tonedawg1@tm_hm_names/meta.json
+++ b/mods/Tonedawg1@tm_hm_names/meta.json
@@ -1,0 +1,20 @@
+{
+  "id": "tm_hm_names",
+  "title": "TM/HM Move Names",
+  "author": "Tonedawg1",
+  "version": "1.1.0",
+  "categories": [
+    "UI",
+    "QOL"
+  ],
+  "repo": "https://github.com/Tonedawg1/gen1recomp-tm-hm-names",
+  "summary": "Shows move names next to TM/HM numbers; long names can scroll the text while the item is highlighted.",
+  "tags": [
+    "qol",
+    "tm",
+    "hm"
+  ],
+  "github": "Tonedawg1/gen1recomp-tm-hm-names",
+  "api": 2,
+  "profile": "content"
+}


### PR DESCRIPTION
Adds `mods/Tonedawg1@tm_hm_names/` — **TM/HM Move Names** 1.1.0 by Tonedawg1.

- Source: https://github.com/Tonedawg1/gen1recomp-tm-hm-names
- Releases tracked from: `Tonedawg1/gen1recomp-tm-hm-names`
- Categories: UI, QOL
- Profile: `content`, mod API 2

Author checklist:

- [ ] `modkit.py validate --strict` and `modkit.py lint` pass
- [ ] the distributed archive contains no ROM-derived content
- [ ] the download URL resolves to a .zip with the mod files at the archive root

<sub>Opened from the submission helper.</sub>