### PR TITLE
Add Cry Manager and Anime Cries - Gen 1

### DIFF
--- a/mods/Leoocast@cry_manager/description.md
+++ b/mods/Leoocast@cry_manager/description.md
@@ -1,0 +1,21 @@
+# Cry Manager
+
+Customize Pokémon cries in Gen1Recomp from **OPTIONS → CRY MANAGER**.
+
+- Choose a sound pack for each species, combine packs, or apply one to all editable species.
+- Restore original cries with Vanilla or Reset All.
+- Keep preferences between sessions, independently of save files.
+- Inspect installed packs and audio validation issues in the menu.
+
+Cry Manager contains no audio. Install a pack separately, such as [Anime Cries - Gen 1](https://github.com/Leoocast/cry-manager-gen1recomp-mod/releases/download/0.2.1/cry_pack_anime_gen1-1.0.0.zip), which includes 151 anime cries organized by Pokédex number.
+
+## Installation
+
+1. Import Cry Manager and your chosen audio pack using the game's **Import mod .zip** option.
+2. Enable both for your chosen game and restart Gen1Recomp.
+3. Open **OPTIONS → CRY MANAGER** and choose individual sounds or **APPLY PACK TO ALL**.
+4. Close and reopen the game to apply your selection.
+
+Tested with Gen1Recomp **0.2.56**. Red and Blue support all 151 species. In Yellow, Pikachu keeps its original game voice; the other 150 species are customizable. Johto support is in development and is not part of this release.
+
+[Watch the showcase](https://www.youtube.com/watch?v=Moyd6FGiXOw) · [Documentation and source](https://github.com/Leoocast/cry-manager-gen1recomp-mod)

--- a/mods/Leoocast@cry_manager/meta.json
+++ b/mods/Leoocast@cry_manager/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "cry_manager",
+  "title": "Cry Manager",
+  "author": "Leoocast",
+  "version": "0.2.1",
+  "summary": "Customize Pokemon cries from Options: mix packs by species, apply an entire pack, or restore original cries. Preferences persist between sessions. Audio packs are installed separately.",
+  "categories": ["AUDIO", "UI"],
+  "tags": ["cries", "sound packs", "pokemon", "gen1"],
+  "repo": "https://github.com/Leoocast/cry-manager-gen1recomp-mod",
+  "github": "Leoocast/cry-manager-gen1recomp-mod",
+  "downloadURL": "https://github.com/Leoocast/cry-manager-gen1recomp-mod/releases/download/0.2.1/cry_manager-0.2.1.zip",
+  "automatic_version_check": true,
+  "api": 2,
+  "game_version": ">=0.2.56 <0.3.0",
+  "profile": "content",
+  "games": ["gen1"],
+  "permissions": []
+}

--- a/mods/Leoocast@cry_pack_anime_gen1/description.md
+++ b/mods/Leoocast@cry_pack_anime_gen1/description.md
@@ -1,0 +1,16 @@
+# Anime Cries - Gen 1
+
+Give your Pokémon their anime voices in Gen1Recomp. This pack contains **151 anime cries**, from Bulbasaur to Mew, organized by National Pokédex number.
+
+Requires **Cry Manager 0.2.1 or later in the 0.2.x series**. The pack adds sounds to the manager; you choose which ones to apply.
+
+## Installation
+
+1. Import [Cry Manager](https://github.com/Leoocast/cry-manager-gen1recomp-mod/releases/download/0.2.1/cry_manager-0.2.1.zip) and this pack using **Import mod .zip**.
+2. Enable both and restart Gen1Recomp.
+3. Open **OPTIONS → CRY MANAGER → APPLY PACK TO ALL**, select **Anime Cries - Gen 1**, and confirm with **YES**. You can also choose sounds individually under **POKEMON CRIES**.
+4. Close and reopen Gen1Recomp to apply the selection. Listen in the Pokédex or in battle.
+
+Tested with Gen1Recomp **0.2.56**. All 151 cries are selectable in Red and Blue. In Yellow, Pikachu keeps its original game voice and the other 150 species use the pack. Johto support is in development and is not included here.
+
+[Watch the showcase](https://www.youtube.com/watch?v=Moyd6FGiXOw) · [Documentation and source](https://github.com/Leoocast/cry-manager-gen1recomp-mod)

--- a/mods/Leoocast@cry_pack_anime_gen1/meta.json
+++ b/mods/Leoocast@cry_pack_anime_gen1/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "cry_pack_anime_gen1",
+  "title": "Anime Cries - Gen 1",
+  "author": "Leoocast",
+  "version": "1.0.0",
+  "summary": "Give Gen 1 Pokemon their anime voices with 151 numbered cries, from Bulbasaur to Mew. Requires Cry Manager. Pikachu keeps its original game voice in Yellow.",
+  "categories": ["AUDIO"],
+  "tags": ["anime", "cries", "sound packs", "pokemon", "gen1"],
+  "repo": "https://github.com/Leoocast/cry-manager-gen1recomp-mod",
+  "downloadURL": "https://github.com/Leoocast/cry-manager-gen1recomp-mod/releases/download/0.2.1/cry_pack_anime_gen1-1.0.0.zip",
+  "automatic_version_check": false,
+  "api": 2,
+  "profile": "content",
+  "games": ["gen1"],
+  "permissions": [],
+  "dependencies": ["cry_manager@>=0.2.1 <0.3.0"]
+}


### PR DESCRIPTION
Adds Cry Manager 0.2.1 and its Anime Cries - Gen 1 pack 1.0.0 as separate mod entries. Cry Manager provides per-species sound selection from Options; the Anime pack supplies the 151 numbered cries and declares its dependency on the manager.

**Author:** Leoocast

**Folders:** `mods/Leoocast@cry_manager/` and `mods/Leoocast@cry_pack_anime_gen1/`

**Source:** https://github.com/Leoocast/cry-manager-gen1recomp-mod

**Release:** https://github.com/Leoocast/cry-manager-gen1recomp-mod/releases/tag/0.2.1

- [x] Cry Manager passes `modkit.py validate --strict`; all packages pass `modkit.py lint`. The packs also load with their dependency using the official modkit loader driver and the native launcher.
- [x] Both distributed ZIPs have the mod's files at the archive root.
- [x] No ROM-derived art, chip banks, ROMs, or patches are distributed.
- [x] `meta.json` matches each mod's `manifest.json` for id, api, profile, permissions, dependencies, and conflicts.
- [x] This PR only adds the two entry folders listed above.

Both entries target Gen 1. Red and Blue support all 151 species; Yellow retains Pikachu's original voice. The descriptions include installation instructions and the showcase video.

Cry Manager tracks the repository's releases. The Anime entry uses a fixed download URL with automatic checks disabled because its 1.0.0 package shares the manager's 0.2.1 release tag.

Validation:

- Official index schema and folder validator: both entries pass without warnings.
- Current index UTF-8, duplicate, blocklist, and index-build checks pass. Both published download URLs return HTTP 200 with an archive content type.
- Official modkit strict validation: Cry Manager passes with the ROM-free fixture and unmodified Gen1Recomp 0.2.56 Lua code.
- Official modkit loader driver: manager, Anime pack, and example load with dependencies mounted together.
- Official modkit content lint: all three distribution packages pass.
- Native Gen1Recomp 0.2.56 installation, reinstall, and restart checks pass; all 151 Anime WAVs decode and play in the isolated test installation.
- Release ZIPs have manifest.json and main.lua at the archive root.

The Lua scan has no denied accesses. It reports the manager's sandboxed load() for its own modules, plus two false positives where its require pattern matches the word "required" in error-message strings. The Anime entry scans without warnings.
