### PR TITLE
Listing update: Contests (was Kanto Contests) — title, summary, tags, description

### DIFF
--- a/mods/MisterMiracle@kanto_contests/description.md
+++ b/mods/MisterMiracle@kanto_contests/description.md
@@ -1,13 +1,41 @@
-Kanto Contests brings Ruby/Sapphire-style Pokémon Contests to
-gen1recomp. **Alpha — playable but unfinished.**
+Pokémon Contests for Crystal, Gold and Silver, played by the Ruby and
+Sapphire rules.
 
-Raise your Pokémon's condition with PokéSnacks, earn and wear contest
-scarves, then enter one of five contests — COOL, BEAUTY, CUTE, SMART,
-or TOUGH — and appeal with your Pokémon's moves scored by contest
-category rather than damage. Available in Kanto and Johto.
+Four contest halls stand across Johto, one rank each: Goldenrod runs
+NORMAL, Ecruteak SUPER, Cianwood HYPER and Blackthorn MASTER. You climb by
+travelling, and a hall takes your entry once the Pokémon you bring has won
+often enough in that category — none for NORMAL, one for SUPER, two for
+HYPER, three for MASTER. Each hall is a real building on its town's street
+with its own lobby and stage, a crowd that grows with the rank and gathers
+around the stage to watch, and three rival coordinators drawn from a cast of
+well over a hundred, gym leaders and named faces among them. The rivals play
+sharper the higher you go.
 
-Wins are recorded per category on the Pokémon, so Ribbons awards the
-matching ribbon automatically if installed. Coordinators and contest
-ranks are still to come.
+Raise a Pokémon's condition with PokéSnacks — five flavours, one per
+category — and earn the matching scarf when a condition reaches 100. Sheen
+is the lifetime feeding limit, so a Pokémon can specialise in two categories
+and no more. An introduction round scores that preparation in audience
+hearts; five turns of judging follow, where each move's contest data decides
+how much it appeals, whether it jams the performer before it, and whether it
+starts or finishes a combo. A move card shows all of it before you commit,
+and filling the applause meter sends the crowd wild.
 
-Works on Red/Blue/Yellow and Gold/Silver/Crystal.
+Someone from a far-off region turns up at MASTER rank, and beating them is
+worth something.
+
+Wins are recorded on the Pokémon, so Kanto Ribbons awards contest ribbons by
+category and rank if it is installed, including for wins made before it was.
+Grand Hall, Trainer Journey and Trophy Case pick up results too.
+
+Every artist whose work appears in the mod is credited in the game itself:
+press START, then CREDITS.
+
+On Red, Blue and Yellow the mod is its original single Celadon contest, with
+the older judging meter. The Johto circuit is Gen 2 for now; bringing the full
+system to Gen 1 is on the list.
+
+Goldenrod, Ecruteak, Cianwood and Blackthorn are edited to fit the halls, so
+this may conflict with another mod that edits those maps — say so in an issue
+and a compatibility patch will follow.
+
+Still growing, and played through end to end on phone and desktop.

--- a/mods/MisterMiracle@kanto_contests/meta.json
+++ b/mods/MisterMiracle@kanto_contests/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "kanto_contests",
-  "title": "Kanto Contests (Alpha)",
+  "title": "Contests",
   "author": "Mister Miracle",
-  "summary": "ALPHA - Ruby/Sapphire-style Pokemon Contests in Kanto and Johto. Raise condition with PokeSnacks, earn scarves, then appeal in COOL, BEAUTY, CUTE, SMART or TOUGH. Wins record per category.",
+  "summary": "Pokemon Contests for Crystal, Gold and Silver: five categories, a four-hall rank circuit across Johto, rival coordinators, snacks, scarves and a Ruby/Sapphire judging round.",
   "version": "0.15.0",
   "categories": [
     "CONTENT",
@@ -10,8 +10,9 @@
   ],
   "tags": [
     "contests",
-    "celadon",
-    "alpha",
+    "johto",
+    "coordinators",
+    "ribbons",
     "gen1",
     "gen2"
   ],


### PR DESCRIPTION
Listing change only for `MisterMiracle@kanto_contests`. **No version bump:** `version` stays `0.15.0` and `github` is unchanged, so the nightly keeps tracking releases as before (CONTRIBUTING, "Keeping the listing current").

The entry had gone stale. The mod is now called **Contests**, and the listing still described a Kanto-only alpha whose "coordinators and contest ranks are still to come" — both shipped a while ago, along with a four-hall rank circuit across Johto.

What changed in `meta.json`:

- `title`: "Kanto Contests (Alpha)" → "Contests"
- `summary`: rewritten, 173 characters
- `tags`: dropped `alpha` and `celadon` (both wrong now), added `johto`, `coordinators` and `ribbons`; `gen1` and `gen2` both stay, since the mod runs on Red/Blue/Yellow as well
- `categories`, `permissions` and everything else: untouched

`description.md` is rewritten from the mod's README: the four halls and what each rank asks of the Pokémon you bring, PokéSnacks and condition and sheen and scarves, the five-turn judging round, the Kanto Ribbons integration, and that artists are credited in game. It no longer claims to be alpha or Kanto-only.

`node scripts/validate.mjs mods/MisterMiracle@kanto_contests` passes with no warnings. Branched from `upstream/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
